### PR TITLE
ENH: Improved binstar capabilities

### DIFF
--- a/building/binstar/meta.yaml
+++ b/building/binstar/meta.yaml
@@ -14,26 +14,34 @@ requirements:
     - setuptools
     - cython
     - numpy
+    - scipy
+    - pandas
+    - patsy
+    - statsmodels
+    - matplotlib
     - ipython-notebook
+    - setuptools
     - pywin32 # [win]
 
   run:
     - python
-    - numpy
+    - setuptools
     - cython
     - numpy
     - scipy
     - pandas
     - patsy
-    - matplotlib
     - statsmodels
+    - matplotlib
+    - ipython-notebook
+    - setuptools
+    - pywin32 # [win]
 
 test:
   imports:
     - arch
   requires:
     - nose
-    
 
 about:
   home: https://github.com/bashtage/arch

--- a/building/binstar_linux.sh
+++ b/building/binstar_linux.sh
@@ -1,11 +1,20 @@
 #!/bin/bash
+cd ..
 
-# Python 2.7
-export CONDA_PY=27
-binstar remove bashtage/arch/1.0/linux-64/arch-1.0-np18py27_0.tar.bz2 --force
-conda build binstar
+sudo Xvfb :99 -nolisten tcp -fbdir /var/run
 
-# Python 3.3
-export CONDA_PY=33
-binstar remove bashtage/arch/1.0/linux-64/arch-1.0-np18py33_0.tar.bz2 --force
-conda build binstar
+## declare Python and Numpy Versions
+declare -a PY_VERSIONS=( "27" "33" "34" )
+declare -a NPY_VERSIONS=( "18" "19" )
+
+## Loop across Python and Numpy
+for PY in "${PY_VERSIONS[@]}"
+do
+    export CONDA_PY=$PY
+    for NPY in "${NPY_VERSIONS[@]}"
+    do
+        export CONDA_NPY=$NPY
+        binstar remove bashtage/arch/1.0/linux-64/arch-1.0-np${NPY}py${PY}_0.tar.bz2 -f
+        conda build ./building/binstar
+    done
+done

--- a/building/binstar_windows.bat
+++ b/building/binstar_windows.bat
@@ -1,68 +1,45 @@
-REM %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-REM Batch file to build binstar binaries from statsmodel head for Python 2.7,
-REM 3.3 and 3.4
-REM
-REM Assumes that
-REM %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-REM %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-REM Python 2.7
-REM %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
+@echo off
+Setlocal EnableDelayedExpansion
 REM Get current directory
 SET CURRENT_WORKING_DIR=%~dp0
-
-REM Set python version
-set CONDA_PY=27
-
-REM Clean up
-call PING 1.1.1.1 -n 1 -w 5000 >NUL
-robocopy C:\Anaconda\conda-bld\work\ c:\temp\conda-work-trash * /MOVE /S 
-del c:\temp\conda-work-trash\*.*? /s
-rmdir C:\Anaconda\conda-bld\work\.git /S /Q
-REM Force a delay to let it complete
-call PING 1.1.1.1 -n 1 -w 60000 >NUL
-
-REM Setup compiler
-set PATH=C:\Program Files (x86)\Microsoft Visual Studio 9.0\Common7\IDE;%PATH%
-set INCLUDE=C:\Program Files\Microsoft SDKs\Windows\v7.0\Include;C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\include;%INCLUDE%
-set LIB=C:\Program Files\Microsoft SDKs\Windows\v7.0\Lib\x64;C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\lib\amd64
-set DISTUTILS_USE_SDK=1
-CALL "C:\temp\setenv" /x64 /release
-
-REM Remove existing version
-binstar remove bashtage/arch/1.0/win-64\arch-1.0-np18py27_0.tar.bz2 --force
-
-REM Build binstar
-conda build binstar
+REM Python and NumPy versions
+set PY_VERSION=27 33 34
+set NPY_VERSION=18 19
 
 
-REM %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-REM Python 3.3
-REM %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+(for %%P in (%PY_VERSION%) do (
+    (for %%N in (%NPY_VERSION%) do (
 
-REM Set python version
-set CONDA_PY=33
+        REM Trick to force a delay. Windows sometimes has issues with rapid file deletion
+        call PING 1.1.1.1 -n 1 -w 5000 >NUL
+        REM Clean up
+        robocopy C:\Anaconda\conda-bld\work\ c:\temp\conda-work-trash * /MOVE /S /NFL /NP
+        robocopy C:\Anaconda\envs\_build\ c:\temp\conda-build-trash * /MOVE /S /NFL /NP
+        del C:\Anaconda\conda-bld\_build\*.*? /s
+        rd /s /q C:\Anaconda\envs\_build
+        del /q c:\temp\conda-work-trash\*.*? /s
+        del /q c:\temp\conda-build-trash\*.*? /s
+        rmdir C:\Anaconda\conda-bld\work\.git /S /Q
+        REM Trick to force a delay. Windows sometimes has issues with rapid file deletion
+        call PING 1.1.1.1 -n 1 -w 30000 >NUL
 
-REM Clean up
-cd %CURRENT_WORKING_DIR%
-REM Force a delay before removal
-call PING 1.1.1.1 -n 1 -w 5000 >NUL
-robocopy C:\Anaconda\conda-bld\work\ c:\temp\conda-work-trash * /MOVE /S 
-del c:\temp\conda-work-trash\*.*? /s
-rmdir C:\Anaconda\conda-bld\work\.git /S /Q
-REM Force a delay to let it complete
-call PING 1.1.1.1 -n 1 -w 60000 >NUL
+        cd %CURRENT_WORKING_DIR%
+        IF %%P==27 (
+            call python2_setup.bat
+        ) ELSE (
+            call python3_setup.bat
+        )
+        set CONDA_PY=%%P
+        set CONDA_NPY=%%N
+        echo Python: !CONDA_PY!, NumPy: !CONDA_NPY!
 
-REM Setup compiler
-set PATH=C:\Program Files (x86)\Microsoft Visual Studio 10.0\Common7\IDE;%PATH%
-cd C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin
-set DISTUTILS_USE_SDK=1
-CALL "C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\setenv" /x64 /release
+        REM Remove from binstar
+        binstar remove bashtage/arch/1.0/win-64\arch-1.0-np!CONDA_NPY!py!CONDA_PY!_0.tar.bz2 --force
+        cd %CURRENT_WORKING_DIR%
+        conda build binstar
 
-REM Remove existing version
-binstar remove bashtage/arch/1.0/win-64\arch-1.0-np18py33_0.tar.bz2 --force
-
-REM Build binstar
-cd %CURRENT_WORKING_DIR%
-conda build binstar
+        REM Trick to force a delay. Windows sometimes has issues with rapid file deletion
+        call PING 1.1.1.1 -n 1 -w 5000 >NUL
+        rd /s /q C:\Anaconda\envs\_build
+        ))
+)) 

--- a/building/python2_setup.bat
+++ b/building/python2_setup.bat
@@ -1,0 +1,9 @@
+echo Python 2.x setup
+REM Setup compiler
+REM The Windows 7 SDK with .Net 3.5 is buggy on Windows 8.  These paths are needed to fix these issues
+set PATH=C:\Program Files (x86)\Microsoft Visual Studio 9.0\Common7\IDE;%PATH%
+set INCLUDE=C:\Program Files\Microsoft SDKs\Windows\v7.0\Include;C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\include;%INCLUDE%
+set LIB=C:\Program Files\Microsoft SDKs\Windows\v7.0\Lib\x64;C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\lib\amd64
+set DISTUTILS_USE_SDK=1
+REM This setenv is the setenv that came with SDK7, with the bugs fixed
+CALL "C:\temp\setenv" /x64 /release

--- a/building/python3_setup.bat
+++ b/building/python3_setup.bat
@@ -1,0 +1,6 @@
+echo Python 3.x setup
+REM Setup compiler
+set PATH=C:\Program Files (x86)\Microsoft Visual Studio 10.0\Common7\IDE;%PATH%
+cd C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin
+set DISTUTILS_USE_SDK=1
+CALL "C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\setenv" /x64 /release


### PR DESCRIPTION
Added ability to build binstar for Python 2.7, 3.3 and 3.4 across NumPy 1.8 and 1.9
