### PR TITLE
FIX: Make bootstrap work with scalar function

### DIFF
--- a/arch/bootstrap/base.py
+++ b/arch/bootstrap/base.py
@@ -520,7 +520,11 @@ class IIDBootstrap(object):
         """
         kwargs = _add_extra_kwargs(self._kwargs, extra_kwargs)
         base = func(*self._args, **kwargs)
-        results = np.zeros((reps, base.shape[0]))
+        try:
+            num_params = base.shape[0]
+        except:
+            num_params = 1
+        results = np.zeros((reps, num_params))
         count = 0
         for pos_data, kw_data in self.bootstrap(reps):
             kwargs = _add_extra_kwargs(kw_data, extra_kwargs)

--- a/arch/bootstrap/tests/test_bootstrap.py
+++ b/arch/bootstrap/tests/test_bootstrap.py
@@ -614,3 +614,19 @@ class TestBootstrap(TestCase):
             direct_results.append(func(*pos))
         direct_results = np.array(direct_results)
         assert_equal(results, direct_results)
+
+    def test_apply_series(self):
+        bs = IIDBootstrap(self.y_series)
+        bs.seed(23456)
+
+        def func(y):
+            return y.mean(0)
+
+        results = bs.apply(func, 1000)
+        bs.reset(23456)
+        direct_results = []
+        for pos, kw in bs.bootstrap(1000):
+            direct_results.append(func(*pos))
+        direct_results = np.array(direct_results)
+        direct_results = direct_results[:,None]
+        assert_equal(results, direct_results)


### PR DESCRIPTION
Bootstrap apply does not currently work with scalar functions since
it expects the value returned to have a shape attribute.