### PR TITLE
BUG: Apply does not work for scalar function

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,15 +33,15 @@ matrix:
     - PYTHON=3.3
     - NUMPY=1.9
     - SCIPY=0.14
-    - NUMBA=0.15
     - MATPLOTLIB=1.4
     - COVERAGE=false
+    - NUMBA=0.16
   - python: 2.7
     env:
     - PYTHON=3.4
     - NUMPY=1.9
-    - SCIPY=0.14
-    - NUMBA=0.16
+    - SCIPY=0.15
+    - NUMBA=0.17
     - MATPLOTLIB=1.4
     - COVERAGE=false
 

--- a/arch/bootstrap/base.py
+++ b/arch/bootstrap/base.py
@@ -520,7 +520,8 @@ class IIDBootstrap(object):
         """
         kwargs = _add_extra_kwargs(self._kwargs, extra_kwargs)
         base = func(*self._args, **kwargs)
-        results = np.zeros((reps, base.shape[0]))
+        noutput = 1 if np.isscalar(base) else base.shape[0]
+        results = np.zeros((reps, noutput))
         count = 0
         for pos_data, kw_data in self.bootstrap(reps):
             kwargs = _add_extra_kwargs(kw_data, extra_kwargs)

--- a/arch/bootstrap/tests/test_bootstrap.py
+++ b/arch/bootstrap/tests/test_bootstrap.py
@@ -614,3 +614,18 @@ class TestBootstrap(TestCase):
             direct_results.append(func(*pos))
         direct_results = np.array(direct_results)
         assert_equal(results, direct_results)
+
+    def test_scalar_function(self):
+        bs = IIDBootstrap(self.y_series)
+        bs.seed(23456)
+        def func(y):
+            return y.mean()
+
+        results = bs.apply(func)
+        bs.seed(23456)
+        direct_results = np.zeros_like(results)
+        i = 0
+        for pos, kw in bs.bootstrap(1000):
+            direct_results[i] = func(*pos)
+            i += 1
+        assert_equal(results, direct_results)


### PR DESCRIPTION
Check dimension of output and use 1 in case of scalar rather then relying
on shape being attached to the object returned.