### PR TITLE
DOC: Require IPython 2 for RTF

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -4,7 +4,7 @@ scipy
 matplotlib
 pandas
 patsy
-ipython
+ipython==2
 statsmodels
 sphinxcontrib-napoleon==0.2.11
 mock


### PR DESCRIPTION
Notebook conversion currently requires IPython 2

[skip ci]