### PR TITLE
Declare encoding to fix SyntaxError: Non-ASCII character '\xe2' in li…

### DIFF
--- a/arch/univariate/distribution.py
+++ b/arch/univariate/distribution.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """
 Distributions to use in ARCH models.  All distributions must inherit from
 :class:`Distribution` and provide the same methods with the same inputs.


### PR DESCRIPTION
It seems that line 341 (or 342 in this branch) "<http://www.ssc.wisc.edu/~bhansen/papers/ier_94.pdf>" is casuing the error in documentation build:
"SyntaxError: Non-ASCII character '\xe2' in file /home/docs/checkouts/readthedocs.org/user_builds/arch/checkouts/latest/doc/source/../../arch/univariate/distribution.py on line 341, but no encoding declared; see http://www.python.org/peps/pep-0263.html for details"
As a result, a lot of sections are missing.

I hope that just adding the first line encoding declaration may save the day. At least it worked with the similar documentation line in my own skewstudent package.