### PR TITLE
Moved glob import in setup.py to make clean command work

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 
 import glob
 import os
+import pkg_resources
 import subprocess
 import sys
 import re
@@ -16,13 +17,15 @@ CMDCLASS = {}
 # prevent setup.py from crashing by calling import numpy before
 # numpy is installed
 class build_ext(_build_ext):
-    def finalize_options(self):
-        _build_ext.finalize_options(self)
+    def build_extensions(self):
+        numpy_incl = pkg_resources.resource_filename('numpy', 'core/include')
 
-        # Prevent numpy from thinking it is still in its setup process:
-        __builtins__.__NUMPY_SETUP__ = False
-        import numpy
-        self.include_dirs.append(numpy.get_include())
+        for ext in self.extensions:
+            if (hasattr(ext, 'include_dirs') and
+                    not numpy_incl in ext.include_dirs):
+                ext.include_dirs.append(numpy_incl)
+        _build_ext.build_extensions(self)
+
 CMDCLASS['build_ext'] = build_ext
 
 SETUP_REQUIREMENTS = {'numpy': '1.7'}

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 
+import glob
 import os
 import subprocess
 import sys
@@ -153,7 +154,6 @@ except ImportError as e:
 try:
     import IPython.nbformat as nbformat
     from IPython.nbconvert import RSTExporter
-    import glob
 
     notebooks = glob.glob(os.path.join(cwd, 'examples', '*.ipynb'))
     for notebook in notebooks:


### PR DESCRIPTION
'python setup.py clean' fails due to the glob module not being present.
Moved glob import statement to the top of the setup.py file to the top
of the file to allow the clean command to work.