### PR TITLE
FIX: Add pval for last model in MCS

### DIFF
--- a/arch/bootstrap/multiple_comparrison.py
+++ b/arch/bootstrap/multiple_comparrison.py
@@ -217,6 +217,10 @@ class MCS(MultipleComparison):
             i = loc.squeeze()[0]
             eliminated.append([indices.flat[i], pval])
             included[indices.flat[i]] = False
+        # Add pval of 1 for model remaining
+        indices = np.argwhere(included).flatten()
+        for ind in indices:
+            eliminated.append([ind, 1.0])
         self._pvalues = self._format_pvalues(eliminated)
 
     def _compute_max(self):

--- a/arch/bootstrap/tests/test_multiple_comparrison.py
+++ b/arch/bootstrap/tests/test_multiple_comparrison.py
@@ -373,3 +373,11 @@ class TestMCS(TestCase):
                     '<strong>bootstrap</strong>: ' + str(mcs.bootstrap) + ', ' +
                     '<strong>ID</strong>: ' + hex(id(mcs)) + ')')
         assert_equal(mcs._repr_html_(), expected)
+
+    def test_all_models_have_pval(self):
+        losses = self.losses_df.iloc[:, :20]
+        mcs = MCS(losses, 0.05, reps=200)
+        mcs.seed(23456)
+        mcs.compute()
+        nan_locs = np.isnan(mcs.pvalues.iloc[:,0])
+        assert_true(not nan_locs.any())

--- a/doc/source/changes/3.0.txt
+++ b/doc/source/changes/3.0.txt
@@ -7,3 +7,4 @@ instead of estimated parameters.
 - Added Hansen's Skew T distribution to distribution (Stanislav Khrapov)
 - Updated IPython notebooks to latest IPython version
 - Bug and typo fixes to IPython notebooks
+- Changed MCS to give a pvalue of 1.0 to best model.  Previously was NaN


### PR DESCRIPTION
Add a p-value of 1.0 for the final model in the MCS.  Previouly
this model had a pvalue of nan.