### PR TITLE
UPD: Update minimum versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ language: python
 env:
   # Default values for common packages, override as needed
   global:
-    - CYTHON=0.20
+    - CYTHON=0.22
     - PATSY=
     - OPTIONAL=
     - STATSMODELS=
@@ -22,13 +22,7 @@ matrix:
   - python: 2.7
     env:
     - PYTHON=2.7
-    - NUMPY=1.7
-    - SCIPY=0.12
     - MATPLOTLIB=1.3
-    - PANDAS=0.12
-  - python: 2.7
-    env:
-    - PYTHON=2.7
     - NUMPY=1.8.2
   - python: 2.7
     env:
@@ -40,7 +34,7 @@ matrix:
     - PYTHON=3.3
     - NUMPY=1.9
     - SCIPY=0.14
-    - NUMBA=0.15
+    - NUMBA=0.20
     - MATPLOTLIB=1.4
     - COVERAGE=false
   - python: 2.7
@@ -56,7 +50,6 @@ matrix:
     - CYTHON=0.23
     - NUMPY=1.10
     - SCIPY=0.16
-    - MATPLOTLIB=1.4
 
 addons:
   apt:
@@ -73,6 +66,7 @@ before_install:
   - chmod +x miniconda.sh
   - ./miniconda.sh -b
   - export PATH=/home/travis/miniconda/bin:$PATH
+  - export PATH=/home/travis/miniconda2/bin:$PATH
   - conda update --yes --quiet conda
   # Fix for headless TravisCI
   - "export DISPLAY=:99.0"

--- a/README.md
+++ b/README.md
@@ -134,15 +134,15 @@ for examples of the multiple comparison procedures.
 
 ## Requirements
 
-* NumPy (1.7+)
-* SciPy (0.12+)
+* NumPy (1.8+)
+* SciPy (0.14+)
 * Pandas (0.14+)
-* statsmodels (0.5+)
+* statsmodels (0.6+)
 * matplotlib (1.3+)
 
 ### Optional Requirements
 
-* Numba (0.15+) will be used if available **and** when installed using the 
+* Numba (0.19+) will be used if available **and** when installed using the 
 --no-binary option
 * IPython (3.0+) is required to run the notebooks
 

--- a/arch/univariate/base.py
+++ b/arch/univariate/base.py
@@ -26,7 +26,6 @@ from ..utility.array import ensure1d, DocStringInheritor, date_to_index
 from ..compat.python import add_metaclass, range
 
 __all__ = ['implicit_constant', 'ARCHModelResult', 'ARCHModel']
-SP14 = LooseVersion(scipy.version.short_version).version[1] >= 14
 
 # Callback variables
 _callback_iter, _callback_llf = 0, 0.0,
@@ -506,18 +505,10 @@ class ARCHModel(object):
         args = (sigma2, backcast, var_bounds)
         f_ieqcons = constraint(a, b)
 
-        if SP14:
-            xopt = fmin_slsqp(func, sv, f_ieqcons=f_ieqcons, bounds=bounds,
-                              args=args, iter=100, acc=1e-06, iprint=1,
-                              full_output=True, epsilon=1.4901161193847656e-08,
-                              callback=_callback, disp=disp)
-        else:
-            if update_freq > 0 and disp:  # Fix limit in SciPy < 0.14
-                disp = 2
-            xopt = fmin_slsqp(func, sv, f_ieqcons=f_ieqcons, bounds=bounds,
-                              args=args, iter=100, acc=1e-06, iprint=1,
-                              full_output=True, epsilon=1.4901161193847656e-08,
-                              disp=disp)
+        xopt = fmin_slsqp(func, sv, f_ieqcons=f_ieqcons, bounds=bounds,
+                          args=args, iter=100, acc=1e-06, iprint=1,
+                          full_output=True, epsilon=1.4901161193847656e-08,
+                          callback=_callback, disp=disp)
 
         # Check convergence
         imode, smode = xopt[3:]

--- a/setup.py
+++ b/setup.py
@@ -28,12 +28,12 @@ class build_ext(_build_ext):
 
 CMDCLASS['build_ext'] = build_ext
 
-SETUP_REQUIREMENTS = {'numpy': '1.7'}
-REQUIREMENTS = {'Cython': '0.20',
-                'matplotlib': '1.2',
-                'scipy': '0.12',
-                'pandas': '0.12',
-                'statsmodels': '0.5',
+SETUP_REQUIREMENTS = {'numpy': '1.8'}
+REQUIREMENTS = {'Cython': '0.22',
+                'matplotlib': '1.3',
+                'scipy': '0.14',
+                'pandas': '0.14',
+                'statsmodels': '0.6',
                 'patsy': '0.2'}
 
 ALL_REQUIREMENTS = SETUP_REQUIREMENTS.copy()


### PR DESCRIPTION
Change minimum versions for testing to

pandas>=0.14
numpy>=0.18
scipy>=0.14
numba>=0.19
matplotlib>=0.13

This reflects recent releases by all of these projects.