### PR TITLE
DOC: Use pandas_datareader and apply pep8

### DIFF
--- a/doc/source/bootstrap/confidence-intervals.rst
+++ b/doc/source/bootstrap/confidence-intervals.rst
@@ -32,14 +32,16 @@ The setup makes use of return data downloaded from Yahoo!
 ::
 
     import datetime as dt
+
     import pandas as pd
-    import pandas.io.data as web
-    start = dt.datetime(1951,1,1)
-    end = dt.datetime(2014,1,1)
-    sp500 = web.get_data_yahoo('^GSPC', start=start, end=end)
-    start = sp500.index.min()
-    end = sp500.index.max()
-    monthly_dates = pd.date_range(start, end, freq='M')
+    import pandas_datareader.data as web
+
+    start = dt.datetime(1951, 1, 1)
+    end = dt.datetime(2014, 1, 1)
+    sp500 = web.DataReader('^GSPC', 'yahoo', start=start, end=end)
+    low = sp500.index.min()
+    high = sp500.index.max()
+    monthly_dates = pd.date_range(low, high, freq='M')
     monthly = sp500.reindex(monthly_dates, method='ffill')
     returns = 100 * monthly['Adj Close'].pct_change().dropna()
 
@@ -54,6 +56,7 @@ The main function used will return a 3-element array containing the parameters.
 .. note::
 
     Functions must return 1-d NumPy arrays or Pandas Series.
+
 
 Confidence Interval Types
 =========================
@@ -77,6 +80,7 @@ order statistics from these empirical distributions.
 ::
 
     from arch.bootstrap import IIDBootstrap
+
     bs = IIDBootstrap(returns)
     ci = bs.conf_int(sharpe_ratio, 1000, method='percentile')
 
@@ -127,6 +131,7 @@ computed element-by-element.
 ::
 
     from arch.bootstrap import IIDBootstrap
+
     bs = IIDBootstrap(returns)
     ci = bs.conf_int(sharpe_ratio, 1000, method='basic')
 
@@ -149,6 +154,7 @@ distribution.
 ::
 
     from arch.bootstrap import IIDBootstrap
+
     bs = IIDBootstrap(returns)
     ci = bs.conf_int(sharpe_ratio, 1000, method='percentile')
 
@@ -170,6 +176,7 @@ error.
 ::
 
     from arch.bootstrap import IIDBootstrap
+
     bs = IIDBootstrap(returns)
     ci = bs.conf_int(sharpe_ratio, 1000, method='norm')
 
@@ -200,6 +207,7 @@ outer bootstraps.
 ::
 
     from arch.bootstrap import IIDBootstrap
+
     bs = IIDBootstrap(returns)
     ci = bs.conf_int(sharpe_ratio, 1000, method='studentized')
 
@@ -273,6 +281,7 @@ parameter is set to 0.
 ::
 
     from arch.bootstrap import IIDBootstrap
+
     bs = IIDBootstrap(returns)
     ci = bs.conf_int(sharpe_ratio, 1000, method='bca')
 
@@ -297,4 +306,3 @@ where :math:`z_{\alpha}` is the usual quantile from the normal distribution and
     \hat{b}=\#\left\{ \hat{\theta}_{b}^{\star}<\hat{\theta}\right\} / B
 
 :math:`a` is a skewness-like estimator using a leave-one-out jackknife.
-

--- a/doc/source/bootstrap/low-level-interface.rst
+++ b/doc/source/bootstrap/low-level-interface.rst
@@ -11,14 +11,16 @@ This example makes use of monthly S&P 500 data.
 ::
 
     import datetime as dt
+
     import pandas as pd
-    import pandas.io.data as web
-    start = dt.datetime(1951,1,1)
-    end = dt.datetime(2014,1,1)
-    sp500 = web.get_data_yahoo('^GSPC', start=start, end=end)
-    start = sp500.index.min()
-    end = sp500.index.max()
-    monthly_dates = pd.date_range(start, end, freq='M')
+    import pandas_datareader.data as web
+
+    start = dt.datetime(1951, 1, 1)
+    end = dt.datetime(2014, 1, 1)
+    sp500 = web.DataReader('^GSPC', 'yahoo', start=start, end=end)
+    low = sp500.index.min()
+    high = sp500.index.max()
+    monthly_dates = pd.date_range(low, high, freq='M')
     monthly = sp500.reindex(monthly_dates, method='ffill')
     returns = 100 * monthly['Adj Close'].pct_change().dropna()
 
@@ -44,6 +46,7 @@ The bootstrapped Sharpe ratios can be directly computed using `apply`.
 
 .. image:: bootstrap_histogram.png
 
+
 The Bootstrap Iterator
 ======================
 The lowest-level method to use a bootstrap is the iterator.  This is used
@@ -60,13 +63,15 @@ bootstrap iterator.
 
     import pandas as pd
     import numpy as np
+
     from arch.bootstrap import IIDBootstrap
-    x = np.random.randn(1000,2)
-    y = pd.DataFrame(np.random.randn(1000,3))
-    z = np.random.rand(1000,10)
+
+    x = np.random.randn(1000, 2)
+    y = pd.DataFrame(np.random.randn(1000, 3))
+    z = np.random.rand(1000, 10)
     bs = IIDBootstrap(x, y=y, z=z)
 
     for pos, kw in bs.bootstrap(1000):
         xstar = pos[0]  # pos is always a tuple, even when a singleton
-        ystar = kw['y'] # A dictionary
+        ystar = kw['y']  # A dictionary
         zstar = kw['z']  # A dictionary

--- a/doc/source/bootstrap/parameter-covariance-estimation.rst
+++ b/doc/source/bootstrap/parameter-covariance-estimation.rst
@@ -10,14 +10,15 @@ Sharpe ratio of the S&P 500 using Yahoo! Finance data.
 ::
 
     import datetime as dt
-    import pandas.io.data as web
     import pandas as pd
-    start = dt.datetime(1951,1,1)
-    end = dt.datetime(2014,1,1)
-    sp500 = web.get_data_yahoo('^GSPC', start=start, end=end)
-    start = sp500.index.min()
-    end = sp500.index.max()
-    monthly_dates = pd.date_range(start, end, freq='M')
+    import pandas_datareader.data as web
+    
+    start = dt.datetime(1951, 1, 1)
+    end = dt.datetime(2014, 1, 1)
+    sp500 = web.DataReader('^GSPC', 'yahoo', start=start, end=end)
+    low = sp500.index.min()
+    high = sp500.index.max()
+    monthly_dates = pd.date_range(low, high, freq='M')
     monthly = sp500.reindex(monthly_dates, method='ffill')
     returns = 100 * monthly['Adj Close'].pct_change().dropna()
 
@@ -37,11 +38,12 @@ bootstrap with an average block size of 12.
 
 ::
 
-    from arch.bootstrap import StationaryBootstrap
     import pandas as pd
+    from arch.bootstrap import StationaryBootstrap
+
     bs = StationaryBootstrap(12, returns)
     param_cov = bs.cov(sharpe_ratio)
-    index = ['mu','sigma','SR']
+    index = ['mu', 'sigma', 'SR']
     params = sharpe_ratio(returns)
     params = pd.Series(params, index=index)
     param_cov = pd.DataFrame(param_cov, index=index, columns=index)

--- a/doc/source/unitroot/introduction.rst
+++ b/doc/source/unitroot/introduction.rst
@@ -1,14 +1,15 @@
 Introduction
 ------------
 
-All tests expect a 1-d series as the first input.  The input can be any array that can `squeeze` into a 1-d array, a pandas
-`Series` or a pandas `DataFrame` that contains a single variable.
+All tests expect a 1-d series as the first input.  The input can be any array that
+can `squeeze` into a 1-d array, a pandas `Series` or a pandas `DataFrame` that
+contains a single variable.
 
 All tests share a common structure.  The key elements are:
 
   * `stat` - Returns the test statistic
   * `pvalue` - Returns the p-value of the test statistic
-  * `lags` - Sets or gets the number of lags used in the model. In most test, can be `None` to trigger automatic selection.
+  * `lags` - Sets or gets the number of lags used in the model.  In most test, can be `None` to trigger automatic selection.
   * `trend` - Sets of gets the trend used in the model.  Supported trends vary by model, but include:
      - `'nc'`: No constant
      - `'c'`: Constant
@@ -16,27 +17,44 @@ All tests share a common structure.  The key elements are:
      - `'ctt'`: Constant, time trend and quadratic time trend
   * `summary()` - Returns a summary object that can be printed to get a formatted table
 
+
 Basic Example
 =============
 
-This basic example show the use of the Augmented-Dickey fuller to test whether the default premium, defined as the
-difference between the yields of large portfolios of BAA and AAA bonds.  This example uses a constant and time trend.
+This basic example show the use of the Augmented-Dickey fuller to test whether the default premium,
+defined as the difference between the yields of large portfolios of BAA and AAA bonds.  This example
+uses a constant and time trend.
 
 
 ::
 
-    import pandas.io.data as web
     import datetime as dt
-    aaa = web.DataReader("AAA", "fred", dt.datetime(1919,1,1), dt.datetime(2014,1,1))
-    baa = web.DataReader("BAA", "fred", dt.datetime(1919,1,1), dt.datetime(2014,1,1))
-    baa.columns = aaa.columns = ['default']
-    default = baa - aaa
+
+    import pandas_datareader.data as web
     from arch.unitroot import ADF
-    adf = ADF(default)
+
+    start = dt.datetime(1919, 1, 1)
+    end = dt.datetime(2014, 1, 1)
+
+    df = web.DataReader(["AAA", "BAA"], "fred", start, end)
+    df['diff'] = df['BAA'] - df['AAA']
+    adf = ADF(df['diff'])
     adf.trend = 'ct'
-    print('Statistic: ' + str(adf.stat))
-    print('P-value: ' + str(adf.pvalue))
-    print('Summary \n')
+
     print(adf.summary())
 
+which yields
 
+::
+
+       Augmented Dickey-Fuller Results   
+    =====================================
+    Test Statistic                 -3.448
+    P-value                         0.045
+    Lags                               21
+    -------------------------------------
+
+    Trend: Constant and Linear Time Trend
+    Critical Values: -3.97 (1%), -3.41 (5%), -3.13 (10%)
+    Null Hypothesis: The process contains a unit root.
+    Alternative Hypothesis: The process is weakly stationary.

--- a/doc/source/univariate/introduction.rst
+++ b/doc/source/univariate/introduction.rst
@@ -25,12 +25,15 @@ function :py:meth:`~arch.arch_model`
 
 ::
 
-    from arch import arch_model
     import datetime as dt
-    import pandas.io.data as web
-    start = dt.datetime(2000,1,1)
-    end = dt.datetime(2014,1,1)
-    sp500 = web.get_data_yahoo('^GSPC', start=start, end=end)
+    
+    import pandas_datareader.data as web
+
+    from arch import arch_model
+
+    start = dt.datetime(2000, 1, 1)
+    end = dt.datetime(2014, 1, 1)
+    sp500 = web.DataReader('^GSPC', 'yahoo', start=start, end=end)
     returns = 100 * sp500['Adj Close'].pct_change().dropna()
     am = arch_model(returns)
 
@@ -40,8 +43,9 @@ blocks of an ARCH model
 ::
 
     from arch import ConstantMean, GARCH, Normal
+
     am = ConstantMean(returns)
-    am.volatility = GARCH(1,0,1)
+    am.volatility = GARCH(1, 0, 1)
     am.distribution = Normal()
 
 In either case, model parameters are estimated using
@@ -51,6 +55,62 @@ In either case, model parameters are estimated using
     res = am.fit()
 
 
+with the following output
+
+::
+
+    Iteration:      1,   Func. Count:      6,   Neg. LLF: 5159.58323938
+    Iteration:      2,   Func. Count:     16,   Neg. LLF: 5156.09760149
+    Iteration:      3,   Func. Count:     24,   Neg. LLF: 5152.29989336
+    Iteration:      4,   Func. Count:     31,   Neg. LLF: 5146.47531817
+    Iteration:      5,   Func. Count:     38,   Neg. LLF: 5143.86337547
+    Iteration:      6,   Func. Count:     45,   Neg. LLF: 5143.02096168
+    Iteration:      7,   Func. Count:     52,   Neg. LLF: 5142.24105141
+    Iteration:      8,   Func. Count:     60,   Neg. LLF: 5142.07138907
+    Iteration:      9,   Func. Count:     67,   Neg. LLF: 5141.416653
+    Iteration:     10,   Func. Count:     73,   Neg. LLF: 5141.39212288
+    Iteration:     11,   Func. Count:     79,   Neg. LLF: 5141.39023885
+    Iteration:     12,   Func. Count:     85,   Neg. LLF: 5141.39023359
+    Optimization terminated successfully.    (Exit mode 0)
+                Current function value: 5141.39023359
+                Iterations: 12
+                Function evaluations: 85
+                Gradient evaluations: 12
+
+::
+
+    print(res.summary())
+
+yields
+
+::
+
+                         Constant Mean - GARCH Model Results                      
+    ==============================================================================
+    Dep. Variable:              Adj Close   R-squared:                      -0.001
+    Mean Model:             Constant Mean   Adj. R-squared:                 -0.001
+    Vol Model:                      GARCH   Log-Likelihood:               -5141.39
+    Distribution:                  Normal   AIC:                           10290.8
+    Method:            Maximum Likelihood   BIC:                           10315.4
+                                            No. Observations:                 3520
+    Date:                Fri, Dec 02 2016   Df Residuals:                     3516
+    Time:                        22:22:28   Df Model:                            4
+                                      Mean Model                                  
+    ==============================================================================
+                     coef    std err          t      P>|t|        95.0% Conf. Int.
+    ------------------------------------------------------------------------------
+    mu             0.0531  1.487e-02      3.569  3.581e-04   [2.392e-02,8.220e-02]
+                                   Volatility Model                               
+    ==============================================================================
+                     coef    std err          t      P>|t|        95.0% Conf. Int.
+    ------------------------------------------------------------------------------
+    omega          0.0156  4.932e-03      3.155  1.606e-03   [5.892e-03,2.523e-02]
+    alpha[1]       0.0879  1.140e-02      7.710  1.260e-14     [6.554e-02,  0.110]
+    beta[1]        0.9014  1.183e-02     76.163      0.000       [  0.878,  0.925]
+    ==============================================================================
+
+    Covariance estimator: robust
+
 
 Core Model Constructor
 ======================
@@ -59,6 +119,7 @@ using a simple model constructor.
 
 .. py:currentmodule:: arch
 .. autofunction:: arch_model
+
 
 Model Results
 =============


### PR DESCRIPTION
`import pandas.io.data as web` no longer works.  Instead, one has to use the outsourced module `pandas_datareader` like so: `import pandas_datareader.data as web`.  On the go, I applied pep8 in the examples.  That is, separate imports from code by one newline and group import statements.