### PR TITLE
TST: Add testing for Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,10 @@ matrix:
     - PYTHON=3.5
     - STATSMODELS_MASTER=true
     - COVERAGE=true
+  - python: 2.7
+    env:
+    - PYTHON=3.6
+    - USE_NUMBA=false
 
 addons:
   apt:
@@ -79,7 +83,7 @@ before_install:
   - PKGS="${PKGS} patsy"; if [ ${PATSY} ]; then PKGS="${PKGS}=${PATSY}"; fi;
   - PKGS="${PKGS} pandas"; if [ ${PANDAS} ]; then PKGS="${PKGS}=${PANDAS}"; fi;
   - PKGS="${PKGS} Cython"; if [ ${CYTHON} ]; then PKGS="${PKGS}=${CYTHON}"; fi;
-  - PKGS="${PKGS} matplotlib"; if [ ${MATPLOTLIB} ]; then PKGS="${PKGS}=${MATPLOTLIB}"; fi;
+  - if [[ ${PYTHON} < "3.6" ]]; then PKGS="${PKGS} matplotlib"; if [ ${MATPLOTLIB} ]; then PKGS="${PKGS}=${MATPLOTLIB}"; fi; fi
   - PKGS="${PKGS} statsmodels"; if [ ${STATSMODELS} ]; then PKGS="${PKGS}=${STATSMODELS}"; fi;
   - if [ ${USE_NUMBA} = true ]; then PKGS="${PKGS} numba"; if [ ${NUMBA} ]; then PKGS="${PKGS}=${NUMBA}";  fi; fi;
   # Fix for missing libgfortran
@@ -87,9 +91,9 @@ before_install:
 
 # Install packages
 install:
-  - conda create --yes --quiet -n arch-test ${PKGS} ${OPTIONAL} statsmodels nbconvert nbformat pytest flake8
+  - conda create --yes --quiet -n arch-test ${PKGS} ${OPTIONAL} statsmodels
   - source activate arch-test
-  - pip install coverage coveralls pytest-cov codecov
+  - pip install flake8 nbconvert nbformat pytest coverage coveralls pytest-cov codecov
   - if [ ${STATSMODELS_MASTER} = true ]; then sh ./ci/statsmodels-master.sh; fi;
   - python setup.py build
   - python setup.py install

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ for examples of the multiple comparison procedures.
 
 ## Requirements
 
+* Python (2.7, 3.4 - 3.6)
 * NumPy (1.9+)
 * SciPy (0.15+)
 * Pandas (0.16+)
@@ -180,7 +181,7 @@ conda install -c https://conda.binstar.org/bashtage arch
 ### Windows
 
 Building extension using the community edition of Visual Studio is
-well supported for Python 3.5.  Building extensions for 64-bit Windows
+well supported for Python 3.5+.  Building extensions for 64-bit Windows
 for use in Python 2.7 is also supported using Microsoft Visual C++
 Compiler for Python 2.7.  Building on combinations of Python/Windows
 is more difficult and is not necessary when Numba is installed since

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,11 +6,11 @@ os: Visual Studio 2015
 environment:
   matrix:
     - PY_MAJOR_VER: 2
-      PYTHON_ARCH: "x86"
-    - PY_MAJOR_VER: 3
       PYTHON_ARCH: "x86_64"
     - PY_MAJOR_VER: 3
       PYTHON_ARCH: "x86"
+    - PY_MAJOR_VER: 3
+      PYTHON_ARCH: "x86_64"
 
 platform:
     - x64

--- a/arch/univariate/recursions_python.py
+++ b/arch/univariate/recursions_python.py
@@ -242,4 +242,5 @@ def egarch_recursion_python(parameters, resids, sigma2, p, o, q, nobs,
 
     return sigma2
 
+
 egarch_recursion = jit(egarch_recursion_python)

--- a/arch/univariate/tests/test_mean.py
+++ b/arch/univariate/tests/test_mean.py
@@ -22,6 +22,11 @@ from arch.univariate.mean import HARX, ConstantMean, ARX, ZeroMean, LS, \
 from arch.univariate.volatility import ConstantVariance, GARCH, HARCH, ARCH, \
     RiskMetrics2006, EWMAVariance, EGARCH
 from arch.univariate.distribution import Normal, StudentsT
+try:
+    import matplotlib.pyplot  # noqa
+    HAS_MATPLOTLIB = True
+except ImportError:
+    HAS_MATPLOTLIB = False
 
 DISPLAY = 'off'
 
@@ -357,12 +362,18 @@ class TestMeanModel(TestCase):
         ar = ARX(self.y, lags=1, volatility=GARCH(), distribution=StudentsT())
         res = ar.fit(disp=DISPLAY, update_freq=5, cov_type='mle')
         res.param_cov
+
+    @pytest.mark.skipif(not HAS_MATPLOTLIB, reason='matplotlib not installed')
+    def test_ar_plot(self):
+        ar = ARX(self.y, lags=1, volatility=GARCH(), distribution=StudentsT())
+        res = ar.fit(disp=DISPLAY, update_freq=5, cov_type='mle')
         res.plot()
         res.plot(annualize='D')
         res.plot(annualize='W')
         res.plot(annualize='M')
         with pytest.raises(ValueError):
             res.plot(annualize='unknown')
+
         res.plot(scale=360)
         res.hedgehog_plot(start=500)
         res.hedgehog_plot(start=500, type='mean')

--- a/arch/utility/exceptions.py
+++ b/arch/utility/exceptions.py
@@ -1,6 +1,7 @@
 class InvalidLengthWarning(Warning):
     pass
 
+
 invalid_length_doc = """
 The length of {var} is not an exact multiple of {block}, and so the final
 {drop} observations have been dropped.
@@ -14,6 +15,7 @@ deprecation_doc = """
 class ConvergenceWarning(Warning):
     pass
 
+
 convergence_warning = """
 The optimizer returned code {code}. The message is:
 {string_message}
@@ -23,6 +25,7 @@ See scipy.optimize.fmin_slsqp for code meaning.
 
 class StartingValueWarning(Warning):
     pass
+
 
 starting_value_warning = """
 Starting values do not satisfy the parameter constraints in the model.  The

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-numpy>=1.7
-scipy>=0.12
-pandas>=0.12
-matplotlib>=1.2
+numpy>=1.9
+scipy>=0.15
+pandas>=0.16
+matplotlib>=1.3
 cython>=0.20
-numba>=0.15
+numba>=0.21
 pytest
 statsmodels>=0.6


### PR DESCRIPTION
Add travis config to test against Python 3.6
Skip matplotlib if not available for testing