### PR TITLE
np.atleast_1d() fix for conf_int(method='bca') on scaler inputs.

### DIFF
--- a/arch/bootstrap/base.py
+++ b/arch/bootstrap/base.py
@@ -461,7 +461,7 @@ class IIDBootstrap(object):
                                   'too small to use BCa'
                         raise RuntimeError(message.format(jk_var=denom))
                     a = numer / denom
-                    a = a[:, None]
+                    a = np.atleast_1d(a)
                 else:
                     a = 0.0
 

--- a/arch/bootstrap/base.py
+++ b/arch/bootstrap/base.py
@@ -462,6 +462,7 @@ class IIDBootstrap(object):
                         raise RuntimeError(message.format(jk_var=denom))
                     a = numer / denom
                     a = np.atleast_1d(a)
+                    a = a[:, None]
                 else:
                     a = 0.0
 

--- a/arch/tests/bootstrap/test_bootstrap.py
+++ b/arch/tests/bootstrap/test_bootstrap.py
@@ -457,6 +457,19 @@ class TestBootstrap(TestCase):
         ci = ci.T
         assert_allclose(ci_db, ci)
 
+    def test_conf_int_bca_scaler(self):
+        num_bootstrap = 100
+        bs = IIDBootstrap(self.y)
+        bs.seed(23456)
+
+        try:
+            ci = bs.conf_int(np.mean, reps=num_bootstrap, method='bca')
+            assert(ci.shape == (2, 1))
+        except IndexError:
+            pytest.fail('conf_int(method=\'bca\') scaler input regression. '
+                        'Ensure output is at least 1D with '
+                        'numpy.atleast_1d().')
+
     def test_conf_int_parametric(self):
         def param_func(x, params=None, state=None):
             if state is not None:


### PR DESCRIPTION
This should resolve #193 with `np.atleast_1d()`. I tested the case listed in the issue and it worked. 

Let me know what you think.

Thanks.