### PR TITLE
BLD/ENH: Allow building wheels without Cython

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,7 +82,7 @@ before_install:
   - echo conda create --yes --quiet -n arch-test ${PKGS}
   - conda create --yes --quiet -n arch-test ${PKGS}
   - source activate arch-test
-  - pip install cached_property flake8 "pytest<4.1" pytest-xdist pytest-cov coverage coveralls codecov nbformat nbconvert!=5.4 jupyter_client ipython jupyter -q
+  - pip install cached_property flake8 pytest pytest-xdist pytest-cov coverage coveralls codecov nbformat nbconvert!=5.4 jupyter_client ipython jupyter -q
   - if [[ "$STATSMODELS_MASTER" == true ]]; then sh ./ci/statsmodels-master.sh; fi;
   - |
     if [[ "$DOCBUILD" == true ]]; then

--- a/arch/compat/numba.py
+++ b/arch/compat/numba.py
@@ -2,11 +2,23 @@ from __future__ import absolute_import, division
 
 import functools
 
+
+class PerformanceWarning(UserWarning):
+    pass
+
+
+performance_warning = '''
+numba is not available, and to this function is being executed without JIT
+compilation. Either installing numba or reinstalling in an environment with
+Cython available is strongly recommended.'''
+
 try:
     from numba import jit
+
     try:
         def f(x, y):
             return x + y
+
         fjit = jit(f, nopython=True, fastmath=True)
         fjit(1.0, 2.0)
         jit = functools.partial(jit, nopython=True, fastmath=True)
@@ -15,8 +27,10 @@ try:
 except ImportError:
     def jit(func, *args, **kwargs):
         def wrapper(*args, **kwargs):
+            import warnings
+            warnings.warn(performance_warning, PerformanceWarning)
             return func(*args, **kwargs)
 
         return wrapper
 
-__all__ = ['jit']
+__all__ = ['jit', 'PerformanceWarning']

--- a/arch/tests/test_compat.py
+++ b/arch/tests/test_compat.py
@@ -1,0 +1,27 @@
+import pytest
+import numpy as np
+from arch.compat.numba import PerformanceWarning
+
+try:
+    import numba  # noqa: F401
+
+    HAS_NUMBA = True
+except ImportError:
+    HAS_NUMBA = False
+
+from arch.univariate.recursions_python import arch_recursion
+
+
+@pytest.mark.skipif(HAS_NUMBA, reason='Can only test when numba is not available.')
+def test_performance_warning():
+    parameters = np.array([1, .1])
+    nobs = 100
+    resids = np.ones(nobs)
+    sigma2 = resids.copy()
+    p = 1
+    backcast = 1.0
+    var_bounds = np.empty((nobs, 2))
+    var_bounds[:, 0] = 0.0
+    var_bounds[:, 1] = 1.0e14
+    with pytest.warns(PerformanceWarning):
+        arch_recursion(parameters, resids, sigma2, p, nobs, backcast, var_bounds)

--- a/arch/tests/univariate/test_recursions.py
+++ b/arch/tests/univariate/test_recursions.py
@@ -32,6 +32,8 @@ try:
 except ImportError:
     missing_numba = True
 
+pytestmark = pytest.mark.filterwarnings('ignore::arch.compat.numba.PerformanceWarning')
+
 
 class Timer(object):
     def __init__(self, first, first_name, second, second_name, model_name,

--- a/setup.py
+++ b/setup.py
@@ -26,8 +26,7 @@ except ImportError:
         raise ImportError('cython is required for cython coverage. Unset '
                           'ARCH_CYTHON_COVERAGE')
 
-    class _build_ext(object):
-        pass
+    from setuptools.command.build_ext import build_ext as _build_ext
 
 FAILED_COMPILER_ERROR = """
 ******************************************************************************


### PR DESCRIPTION
Improve setup to succeed without Cython.
Show a performance warning when pure Python recusions are being executed.