### PR TITLE
ENH: Expose random_state in mean forecast

### DIFF
--- a/arch/tests/univariate/test_forecast.py
+++ b/arch/tests/univariate/test_forecast.py
@@ -379,6 +379,19 @@ class TestForecasting(TestCase):
             lrv.iloc[:, i:i + 1] = rv.values[:, :i + 1].dot(weights[::-1])
         assert_frame_equal(lrv, forecast.variance)
 
+    def test_ar1_forecast_bootstrap(self):
+        am = arch_model(self.ar1, mean='AR', vol='GARCH', lags=[1])
+        res = am.fit(disp='off')
+        rs = np.random.RandomState(98765432)
+        state = rs.get_state()
+        forecast = res.forecast(horizon=5, start=900, method='bootstrap',
+                                random_state=rs)
+        rs.set_state(state)
+        repeat = res.forecast(horizon=5, start=900, method='bootstrap',
+                              random_state=rs)
+        assert_frame_equal(forecast.mean, repeat.mean, check_less_precise=True)
+        assert_frame_equal(forecast.variance, repeat.variance, check_less_precise=True)
+
     def test_ar2_garch11(self):
         pass
 

--- a/arch/univariate/base.py
+++ b/arch/univariate/base.py
@@ -712,7 +712,7 @@ class ARCHModel(object):
 
     @abstractmethod
     def forecast(self, params, horizon=1, start=None, align='origin', method='analytic',
-                 simulations=1000, rng=None):
+                 simulations=1000, rng=None, random_state=None):
         """
         Construct forecasts from estimated model
 
@@ -749,6 +749,8 @@ class ARCHModel(object):
             Custom random number generator to use in simulation-based forecasts.
             Must produce random samples using the syntax `rng(size)` where size
             the 2-element tuple (simulations, horizon).
+        random_state : RandomState, optional
+            NumPy RandomState instance to use when method is 'bootstrap'
 
         Returns
         -------
@@ -1114,7 +1116,7 @@ class ARCHModelFixedResult(_SummaryRepr):
         return fig
 
     def forecast(self, params=None, horizon=1, start=None, align='origin', method='analytic',
-                 simulations=1000, rng=None):
+                 simulations=1000, rng=None, random_state=None):
         """
         Construct forecasts from estimated model
 
@@ -1151,6 +1153,8 @@ class ARCHModelFixedResult(_SummaryRepr):
             Custom random number generator to use in simulation-based forecasts.
             Must produce random samples using the syntax `rng(size)` where size
             the 2-element tuple (simulations, horizon).
+        random_state : RandomState, optional
+            NumPy RandomState instance to use when method is 'bootstrap'
 
         Returns
         -------
@@ -1185,7 +1189,8 @@ class ARCHModelFixedResult(_SummaryRepr):
             if (params.size != np.array(self._params).size or
                     params.ndim != self._params.ndim):
                 raise ValueError('params have incorrect dimensions')
-        return self.model.forecast(params, horizon, start, align, method, simulations, rng)
+        return self.model.forecast(params, horizon, start, align, method, simulations, rng,
+                                   random_state)
 
     def hedgehog_plot(self, params=None, horizon=10, step=10, start=None,
                       type='volatility', method='analytic', simulations=1000):

--- a/arch/univariate/mean.py
+++ b/arch/univariate/mean.py
@@ -610,7 +610,7 @@ class HARX(ARCHModel):
                                copy.deepcopy(self))
 
     def forecast(self, params, horizon=1, start=None, align='origin',
-                 method='analytic', simulations=1000, rng=None):
+                 method='analytic', simulations=1000, rng=None, random_state=None):
         # Check start
         earliest, default_start = self._fit_indices
         default_start = max(0, default_start - 1)
@@ -635,10 +635,10 @@ class HARX(ARCHModel):
         if rng is None:
             rng = self._distribution.simulate(dp)
         variance_start = max(0, start_index - earliest)
-        vfcast = self._volatility.forecast(vp, full_resids, backcast, vb,
-                                           start=variance_start,
+        vfcast = self._volatility.forecast(vp, full_resids, backcast, vb, start=variance_start,
                                            horizon=horizon, method=method,
-                                           simulations=simulations, rng=rng)
+                                           simulations=simulations, rng=rng,
+                                           random_state=random_state)
         var_fcasts = vfcast.forecasts
         var_fcasts = _forecast_pad(earliest, var_fcasts)
 

--- a/doc/source/changes/4.0.txt
+++ b/doc/source/changes/4.0.txt
@@ -1,3 +1,12 @@
+Changes since 4.8.1
+===================
+- Added `random_state` argument to :func:`~arch.univariate.HARX.forecast`
+  to allow a :class:`~numpy.random.RandomState` object to be passed in when
+  forecasting when `method='bootstrap'`. This allows the repeatable forecast to
+  be produced (:issue:`290`).
+- Fixed a bug in :class:`~arch.unitroot.VarianceRatio` that used the wrong
+  variance in nonrobust inference with overlapping samples (:issue:`286`).
+
 Release 4.8.1
 =============
 - Fixed a bug which prevented extension modules from being correctly imported.

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -14,7 +14,7 @@ Contents
 ========
 
 .. toctree::
-    :maxdepth: 3
+    :maxdepth: 2
 
     Univariate Volatility Models <univariate/univariate>
     Bootstrapping <bootstrap/bootstrap>


### PR DESCRIPTION
Allow random_state to be passed from a mean forecast to facilitate reproducibility

closes #290