### PR TITLE
fix bca calculation

### DIFF
--- a/arch/bootstrap/base.py
+++ b/arch/bootstrap/base.py
@@ -487,7 +487,7 @@ class IIDBootstrap(object):
                     nobs = self._num_items
                     jk_params = _loo_jackknife(func, nobs, self._args,
                                                self._kwargs)
-                    u = (nobs - 1) * (jk_params - jk_params.mean())
+                    u = jk_params.mean() - jk_params
                     numer = np.sum(u ** 3, 0)
                     denom = 6 * (np.sum(u ** 2, 0) ** (3.0 / 2.0))
                     small = denom < (np.abs(numer) * np.finfo(np.float64).eps)

--- a/arch/bootstrap/base.py
+++ b/arch/bootstrap/base.py
@@ -501,6 +501,10 @@ class IIDBootstrap(object):
                 else:
                     a = 0.0
 
+                # TODO: save these parameters?
+                self._a = a
+                self._b = b
+
                 percentiles = stats.norm.cdf(b + (b + norm_quantiles) /
                                              (1.0 - a * (b + norm_quantiles)))
                 percentiles = list(100 * percentiles)

--- a/arch/bootstrap/base.py
+++ b/arch/bootstrap/base.py
@@ -20,6 +20,35 @@ except ImportError:  # pragma: no cover
     from arch.bootstrap._samplers_python import stationary_bootstrap_sample
 
 
+def _get_acceleration(jk_params):
+    """
+    Estimates the BCa acceleration parameter using jackknife estimates
+    of theta.
+
+    Parameters
+    ----------
+    jk_params : ndarray
+        Array containing the jackknife results where row i corresponds to
+        leaving observation i out of the sample. Returned by _loo_jackknife.
+
+    Returns
+    -------
+    a : float
+        Value of the acceleration parameter "a" used in the BCa bootstrap.
+    """
+    u = jk_params.mean() - jk_params
+    numer = np.sum(u**3, 0)
+    denom = 6 * (np.sum(u**2, 0)**(3.0 / 2.0))
+    small = denom < (np.abs(numer) * np.finfo(np.float64).eps)
+    if small.any():
+        message = 'Jackknife variance estimate {jk_var} is ' \
+                    'too small to use BCa'
+        raise RuntimeError(message.format(jk_var=denom))
+    a = numer / denom
+    a = np.atleast_1d(a)
+    return a[:, None]
+
+
 def _loo_jackknife(func, nobs, args, kwargs):
     """
     Leave one out jackknife estimation
@@ -480,31 +509,11 @@ class IIDBootstrap(object):
             if method in ('debiased', 'bc', 'bias-corrected', 'bca'):
                 # bias corrected uses modified percentiles, but is
                 # otherwise identical to the percentile method
-                p = (results < base).mean(axis=0)
-                b = stats.norm.ppf(p)
-                b = b[:, None]
+                b = self.get_bca_bias()
                 if method == 'bca':
-                    nobs = self._num_items
-                    jk_params = _loo_jackknife(func, nobs, self._args,
-                                               self._kwargs)
-                    u = jk_params.mean() - jk_params
-                    numer = np.sum(u ** 3, 0)
-                    denom = 6 * (np.sum(u ** 2, 0) ** (3.0 / 2.0))
-                    small = denom < (np.abs(numer) * np.finfo(np.float64).eps)
-                    if small.any():
-                        message = 'Jackknife variance estimate {jk_var} is ' \
-                                  'too small to use BCa'
-                        raise RuntimeError(message.format(jk_var=denom))
-                    a = numer / denom
-                    a = np.atleast_1d(a)
-                    a = a[:, None]
+                    a = self.get_bca_acceleration(func)
                 else:
                     a = 0.0
-
-                # TODO: save these parameters?
-                self._a = a
-                self._b = b
-
                 percentiles = stats.norm.cdf(b + (b + norm_quantiles) /
                                              (1.0 - a * (b + norm_quantiles)))
                 percentiles = list(100 * percentiles)
@@ -546,6 +555,16 @@ class IIDBootstrap(object):
             lower.fill(-1 * np.inf)
 
         return np.vstack((lower, upper))
+
+    def get_bca_bias(self):
+        p = (self._results < self._base).mean(axis=0)
+        b = stats.norm.ppf(p)
+        return b[:, None]
+
+    def get_bca_acceleration(self, func):
+        nobs = self._num_items
+        jk_params = _loo_jackknife(func, nobs, self._args, self._kwargs)
+        return _get_acceleration(jk_params)
 
     def clone(self, *args, **kwargs):
         """

--- a/arch/tests/bootstrap/test_bootstrap.py
+++ b/arch/tests/bootstrap/test_bootstrap.py
@@ -593,10 +593,16 @@ class TestBootstrap(TestCase):
         # bca_lims = np.array(output[1])[:, 0]
         # # bca confidence intervals for: 0.025, 0.05, 0.1, 0.16, 0.5, 0.84, 0.9, 0.95, 0.975
         # bcajack_ci_90 = [bca_lims[1], bca_lims[-2]]
+        # print('bcajack_ci_90: {}'.format(bcajack_ci_90))
         arch_ci = list(arch_ci[:, -1])
         print('arch ci: {}'.format(arch_ci))
-        bcajack_ci_90 = [0.4275558602676563, 0.5321144646287552]
-        assert_allclose(arch_ci, bcajack_ci_90, atol=0.005)
+        # bcajack should estimate similar "a" using jackknife on the same observations
+        assert_allclose(arch_bs._a, -0.0004068984)
+        # bcajack returns b (or z0) = -0.03635412, but based on different bootstrap samples
+        assert_allclose(arch_bs._b, 0.04764396)
+        # bcajack_ci_90 = [0.42696, 0.53188]
+        saved_arch_ci_90 = [0.42719805360154717, 0.5336561953393736]
+        assert_allclose(arch_ci, saved_arch_ci_90)
 
     def test_bca(self):
         num_bootstrap = 20

--- a/arch/tests/bootstrap/test_bootstrap.py
+++ b/arch/tests/bootstrap/test_bootstrap.py
@@ -545,6 +545,9 @@ class TestBootstrap(TestCase):
         results_series = _loo_jackknife(self.func, len(y), (y,), {})
         assert_allclose(results, results_series)
 
+    def test_bca_against_bcajack(self):
+        pass
+
     def test_bca(self):
         num_bootstrap = 20
         bs = IIDBootstrap(self.x)
@@ -563,7 +566,7 @@ class TestBootstrap(TestCase):
         base = self.func(self.x)
         nobs = self.x.shape[0]
         jk = _loo_jackknife(self.func, nobs, [self.x], {})
-        u = (nobs - 1) * (jk - jk.mean())
+        u = jk.mean() - jk
         u2 = np.sum(u * u, 0)
         u3 = np.sum(u * u * u, 0)
         a = u3 / (6.0 * (u2 ** 1.5))

--- a/arch/tests/bootstrap/test_bootstrap.py
+++ b/arch/tests/bootstrap/test_bootstrap.py
@@ -557,7 +557,10 @@ class TestBootstrap(TestCase):
         except Exception:
             utils.install_packages('bcaboot', repos='http://cran.us.r-project.org')
             bcaboot = importr('bcaboot')
-        observations = np.random.multivariate_normal(mean=[8, 4], cov=np.identity(2), size=20)
+
+        rng_seed_obs = 42
+        rs = np.random.RandomState(rng_seed_obs)
+        observations = rs.multivariate_normal(mean=[8, 4], cov=np.identity(2), size=20)
         n = observations.shape[0]
         eta = observations.mean(axis=0)
         cov = np.identity(2)

--- a/arch/tests/bootstrap/test_bootstrap.py
+++ b/arch/tests/bootstrap/test_bootstrap.py
@@ -588,8 +588,10 @@ class TestBootstrap(TestCase):
         # output = bcaboot.bcajack(x=observations, B=float(B), func=func_r)
         # print(output[1])
         # print(output[2])
-        print('\narch [ a: {} ]'.format(arch_bs._a))
-        print('arch [ b: {} ]'.format(arch_bs._b))
+        a = arch_bs.get_bca_acceleration(func)
+        b = arch_bs.get_bca_bias()
+        print('\narch [ a: {} ]'.format(a))
+        print('arch [ b: {} ]'.format(b))
         # bca_lims = np.array(output[1])[:, 0]
         # # bca confidence intervals for: 0.025, 0.05, 0.1, 0.16, 0.5, 0.84, 0.9, 0.95, 0.975
         # bcajack_ci_90 = [bca_lims[1], bca_lims[-2]]
@@ -597,9 +599,9 @@ class TestBootstrap(TestCase):
         arch_ci = list(arch_ci[:, -1])
         print('arch ci: {}'.format(arch_ci))
         # bcajack should estimate similar "a" using jackknife on the same observations
-        assert_allclose(arch_bs._a, -0.0004068984)
+        assert_allclose(a, -0.0004068984)
         # bcajack returns b (or z0) = -0.03635412, but based on different bootstrap samples
-        assert_allclose(arch_bs._b, 0.04764396)
+        assert_allclose(b, 0.04764396)
         # bcajack_ci_90 = [0.42696, 0.53188]
         saved_arch_ci_90 = [0.42719805360154717, 0.5336561953393736]
         assert_allclose(arch_ci, saved_arch_ci_90)

--- a/arch/tests/bootstrap/test_bootstrap.py
+++ b/arch/tests/bootstrap/test_bootstrap.py
@@ -546,17 +546,17 @@ class TestBootstrap(TestCase):
         assert_allclose(results, results_series)
 
     def test_bca_against_bcajack(self):
-        import rpy2.rinterface as ri
-        import rpy2.robjects as robjects
-        import rpy2.robjects.numpy2ri
-        from rpy2.robjects.packages import importr
-        rpy2.robjects.numpy2ri.activate()
-        utils = importr('utils')
-        try:
-            bcaboot = importr('bcaboot')
-        except Exception:
-            utils.install_packages('bcaboot', repos='http://cran.us.r-project.org')
-            bcaboot = importr('bcaboot')
+        # import rpy2.rinterface as ri
+        # import rpy2.robjects as robjects
+        # import rpy2.robjects.numpy2ri
+        # from rpy2.robjects.packages import importr
+        # rpy2.robjects.numpy2ri.activate()
+        # utils = importr('utils')
+        # try:
+        #     bcaboot = importr('bcaboot')
+        # except Exception:
+        #     utils.install_packages('bcaboot', repos='http://cran.us.r-project.org')
+        #     bcaboot = importr('bcaboot')
 
         rng_seed_obs = 42
         rs = np.random.RandomState(rng_seed_obs)
@@ -581,24 +581,24 @@ class TestBootstrap(TestCase):
             method='bca',
         )
 
-        # callable from R
-        @ri.rternalize
-        def func_r(x):
-            x = np.asarray(x)
-            _mean = x.mean(axis=0)
-            return float(_mean[1] / _mean[0])
+        # # callable from R
+        # @ri.rternalize
+        # def func_r(x):
+        #     x = np.asarray(x)
+        #     _mean = x.mean(axis=0)
+        #     return float(_mean[1] / _mean[0])
 
-        output = bcaboot.bcajack(x=observations, B=float(B), func=func_r)
-        print(output[1])
-        print(output[2])
-        print('arch [ a: {} ]'.format(arch_bs._a))
+        # output = bcaboot.bcajack(x=observations, B=float(B), func=func_r)
+        # print(output[1])
+        # print(output[2])
+        print('\narch [ a: {} ]'.format(arch_bs._a))
         print('arch [ b: {} ]'.format(arch_bs._b))
+        # bca_lims = np.array(output[1])[:, 0]
+        # # bca confidence intervals for: 0.025, 0.05, 0.1, 0.16, 0.5, 0.84, 0.9, 0.95, 0.975
+        # bcajack_ci_90 = [bca_lims[1], bca_lims[-2]]
         arch_ci = list(arch_ci[:, -1])
-        bca_lims = np.array(output[1])[:, 0]
-        # bca confidence intervals for: 0.025, 0.05, 0.1, 0.16, 0.5, 0.84, 0.9, 0.95, 0.975
-        bcajack_ci_90 = [bca_lims[1], bca_lims[-2]]
-        print(arch_ci)
-        print(bcajack_ci_90)
+        print('arch ci: {}'.format(arch_ci))
+        bcajack_ci_90 = [0.4275558602676563, 0.5321144646287552]
         assert_allclose(arch_ci, bcajack_ci_90, atol=0.005)
 
     def test_bca(self):

--- a/arch/tests/bootstrap/test_bootstrap.py
+++ b/arch/tests/bootstrap/test_bootstrap.py
@@ -561,9 +561,6 @@ class TestBootstrap(TestCase):
         rng_seed_obs = 42
         rs = np.random.RandomState(rng_seed_obs)
         observations = rs.multivariate_normal(mean=[8, 4], cov=np.identity(2), size=20)
-        n = observations.shape[0]
-        eta = observations.mean(axis=0)
-        cov = np.identity(2)
         B = 2000
         rng_seed = 123
         rs = np.random.RandomState(rng_seed)


### PR DESCRIPTION
Checks bca jackknife against bcaboot package using rpy2. Imports are in the new test function to call out the test dependency. Those can be moved to the top if taken. 