### PR TITLE
BUG: Clarify that BCa can't be used with unequal samples

### DIFF
--- a/arch/bootstrap/base.py
+++ b/arch/bootstrap/base.py
@@ -511,6 +511,12 @@ class IIDBootstrap(object):
                 # otherwise identical to the percentile method
                 b = self.get_bca_bias()
                 if method == 'bca':
+                    lens = [len(arg) for arg in self._args] + \
+                           [len(kwarg) for kwarg in self._kwargs.values()]
+                    if min(lens) != max(lens):
+                        raise ValueError('BCa cannot be applied to statistics '
+                                         'computed from datasets with '
+                                         'different lengths')
                     a = self.get_bca_acceleration(func)
                 else:
                     a = 0.0

--- a/arch/tests/bootstrap/test_bootstrap.py
+++ b/arch/tests/bootstrap/test_bootstrap.py
@@ -793,6 +793,9 @@ def test_unequal_bs():
     variance = bs.var(mean_diff)
     assert variance > 0
 
+    with pytest.raises(ValueError, match='BCa cannot be applied'):
+        bs.conf_int(mean_diff, method='bca')
+
 
 def test_unequal_bs_kwargs():
     def mean_diff(x, y):


### PR DESCRIPTION
Clarify that BCa isn't applicable