### PR TITLE
BUG: Pass extra_kwarg into bca calculations

### DIFF
--- a/arch/bootstrap/base.py
+++ b/arch/bootstrap/base.py
@@ -202,6 +202,7 @@ def _loo_jackknife(
     nobs: int,
     args: Sequence[ArrayLike],
     kwargs: Dict[str, ArrayLike],
+    extra_kwargs: Optional[Dict[str, ArrayLike]] = None,
 ) -> NDArray:
     """
     Leave one out jackknife estimation
@@ -238,6 +239,8 @@ def _loo_jackknife(
                 kwargs_copy[k] = v.iloc[items]
             else:
                 kwargs_copy[k] = v[items]
+        if extra_kwargs is not None:
+            kwargs_copy.update(extra_kwargs)
         results.append(func(*args_copy, **kwargs_copy))
     return np.array(results)
 
@@ -721,7 +724,7 @@ class IIDBootstrap(object, metaclass=DocStringInheritor):
                             "computed from datasets with "
                             "different lengths"
                         )
-                    a = self._bca_acceleration(func)
+                    a = self._bca_acceleration(func, extra_kwargs)
                 else:
                     a = 0.0
                 percentiles = stats.norm.cdf(
@@ -777,9 +780,11 @@ class IIDBootstrap(object, metaclass=DocStringInheritor):
         b = stats.norm.ppf(p)
         return b[:, None]
 
-    def _bca_acceleration(self, func: Callable[..., ArrayLike]) -> float:
+    def _bca_acceleration(
+        self, func: Callable[..., ArrayLike], extra_kwags: Optional[Dict[str, Any]]
+    ) -> float:
         nobs = self._num_items
-        jk_params = _loo_jackknife(func, nobs, self._args, self._kwargs)
+        jk_params = _loo_jackknife(func, nobs, self._args, self._kwargs, extra_kwags)
         return _get_acceleration(jk_params)
 
     def clone(self, *args: ArrayLike, **kwargs: ArrayLike) -> "IIDBootstrap":

--- a/arch/tests/bootstrap/test_bootstrap.py
+++ b/arch/tests/bootstrap/test_bootstrap.py
@@ -761,7 +761,7 @@ def test_bca_against_bcajack():
     #     _mean = x.mean(axis=0)
     #     return float(_mean[1] / _mean[0])
     # output = bcaboot.bcajack(x=observations, B=float(B), func=func_r)
-    a = arch_bs._bca_acceleration(func)
+    a = arch_bs._bca_acceleration(func, None)
     b = arch_bs._bca_bias()
     # bca_lims = np.array(output[1])[:, 0]
     # # bca confidence intervals for: 0.025, 0.05, 0.1, 0.16, 0.5,
@@ -928,3 +928,15 @@ def test_list_input():
     with pytest.raises(TypeError, match="Input `data` "):
         vals = np.random.standard_normal(25).tolist()
         IIDBootstrap(data=vals)
+
+
+def test_bca_extra_kwarg():
+    # GH 366
+    def f(a, b):
+        return a.mean(0)
+
+    x = np.random.standard_normal(1000)
+    bs = IIDBootstrap(x)
+    ci = bs.conf_int(f, extra_kwargs={"b": "anything"}, reps=100, method="bca")
+    assert isinstance(ci, np.ndarray)
+    assert ci.shape == (2, 1)

--- a/doc/source/changes/4.0.txt
+++ b/doc/source/changes/4.0.txt
@@ -4,6 +4,7 @@ Version 4
 
 Since 4.12
 ==========
+- Fixed a bug when using "bca" confidence intervals with ``extra_kwargs`` (:issue:`366`).
 - Added Phillips-Ouliaris (:func:`~arch.unitroot.cointegration.phillips_ouliaris`)
   cointegration tests (:issue:`360`).
 - Added three methods to estimate cointegrating vectors:


### PR DESCRIPTION
extra_kwargs was not being passed into the bca acceleration function

closes #366