### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ for examples of testing series for unit roots.
 ### Cointegration Testing and Analysis
 
 - Tests
-  - Emgle-Granger Test
+  - Engle-Granger Test
   - Phillips-Ouliaris Test
 - Cointegration Vector Estimation
   - Canonical Cointegrating Regression 


### PR DESCRIPTION
The name of the scientist 'Engle' for Engle-Granger Test was mistakenly written as 'Emgle' in the cointegration tests section.