### PR TITLE
update an equation in forecasting.rst

### DIFF
--- a/doc/source/univariate/forecasting.rst
+++ b/doc/source/univariate/forecasting.rst
@@ -74,7 +74,7 @@ Variance forecasts are constructed for the conditional variances as
    :nowrap:
 
    \begin{eqnarray}
-      \sigma^2_{t+1} & = & \omega + \alpha \epsilon_t^2 + \beta \sigma^2_{t-1} \\
+      \sigma^2_{t+1} & = & \omega + \alpha \epsilon_t^2 + \beta \sigma^2_t \\
       \sigma^2_{t+h} & = & \omega + \alpha  E_{t}[\epsilon_{t+h-1}^2] + \beta E_{t}[\sigma^2_{t+h-1}] \, h \geq 2 \\
                      & = & \omega + \left(\alpha  + \beta\right) E_{t}[\sigma^2_{t+h-1}] \, h \geq 2
    \end{eqnarray}


### PR DESCRIPTION
An equation in forecasting.rst is wrong.
This is insignificant, but I think `t` is correct subscript for this equation, not `t-1`. Could you review and merge if this is the right correction?
Thank you.