### PR TITLE
Update Python 3.9 build requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,9 +2,9 @@
 requires = [
   "setuptools",
   "wheel",
-  "numpy==1.14.6; python_version=='3.6'",
-  "numpy==1.14.6; python_version=='3.7'",
-  "numpy==1.17.5; python_version>='3.8'",
+  "numpy>=1.14.6; python_version=='3.6'",
+  "numpy>=1.14.6; python_version=='3.7'",
+  "numpy>=1.17.5; python_version>='3.8'",
   "Cython>=0.29.14"]
 
 [tool.black]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,9 +2,10 @@
 requires = [
   "setuptools",
   "wheel",
-  "numpy>=1.14.6; python_version=='3.6'",
-  "numpy>=1.14.6; python_version=='3.7'",
-  "numpy>=1.17.5; python_version>='3.8'",
+  "numpy==1.14.6; python_version=='3.6'",
+  "numpy==1.14.6; python_version=='3.7'",
+  "numpy==1.17.5; python_version=='3.8'",
+  "numpy; python_version>='3.9'",
   "Cython>=0.29.14"]
 
 [tool.black]


### PR DESCRIPTION
Hardcoding the numpy version may introduce build errors on old version, e.g.:

https://github.com/numpy/numpy/pull/17906