### PR TITLE
MAINT: Make typing_extensions optional

### DIFF
--- a/arch/bootstrap/_samplers_python.py
+++ b/arch/bootstrap/_samplers_python.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from arch.compat.numba import jit
 
 from arch.typing import NDArray

--- a/arch/bootstrap/base.py
+++ b/arch/bootstrap/base.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import copy
 from typing import (
     Any,
@@ -796,7 +798,7 @@ class IIDBootstrap(object, metaclass=DocStringInheritor):
         jk_params = _loo_jackknife(func, nobs, self._args, self._kwargs, extra_kwags)
         return _get_acceleration(jk_params)
 
-    def clone(self, *args: ArrayLike, **kwargs: ArrayLike) -> "IIDBootstrap":
+    def clone(self, *args: ArrayLike, **kwargs: ArrayLike) -> IIDBootstrap:
         """
         Clones the bootstrap using different data with a fresh RandomState.
 

--- a/arch/bootstrap/multiple_comparison.py
+++ b/arch/bootstrap/multiple_comparison.py
@@ -1,10 +1,23 @@
-import sys
-from typing import Any, Dict, Hashable, List, Optional, Sequence, Tuple, Union, cast
+from __future__ import annotations
 
-if sys.version_info < (3, 8):
-    from typing_extensions import Literal
-else:
+import sys
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    Hashable,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+    cast,
+)
+
+if sys.version_info >= (3, 8):
     from typing import Literal
+elif TYPE_CHECKING:
+    from typing_extensions import Literal
 
 import numpy as np
 import pandas as pd

--- a/arch/covariance/kernel.py
+++ b/arch/covariance/kernel.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from typing import List, Optional
 

--- a/arch/typing.py
+++ b/arch/typing.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime as dt
 from typing import Callable, Hashable, Optional, Tuple, TypeVar, Union
 

--- a/arch/unitroot/_engle_granger.py
+++ b/arch/unitroot/_engle_granger.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Optional
 
 import numpy as np
@@ -32,7 +34,7 @@ def engle_granger(
     lags: Optional[int] = None,
     max_lags: Optional[int] = None,
     method: str = "bic",
-) -> "EngleGrangerTestResults":
+) -> EngleGrangerTestResults:
     r"""
     Test for cointegration within a set of time series.
 

--- a/arch/unitroot/_phillips_ouliaris.py
+++ b/arch/unitroot/_phillips_ouliaris.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Optional
 
 import numpy as np
@@ -42,7 +44,7 @@ def _po_ptests(
     kernel: str,
     bandwidth: Optional[int],
     force_int: bool,
-) -> "PhillipsOuliarisTestResults":
+) -> PhillipsOuliarisTestResults:
     nobs = z.shape[0]
     z_lead = z.iloc[1:]
     z_lag = add_trend(z.iloc[:-1], trend=trend)
@@ -94,7 +96,7 @@ def _po_ztests(
     kernel: str,
     bandwidth: Optional[int],
     force_int: bool,
-) -> "PhillipsOuliarisTestResults":
+) -> PhillipsOuliarisTestResults:
     # Za and Zt tests
     u = np.asarray(xsection.resid)[:, None]
     nobs = u.shape[0]
@@ -139,7 +141,7 @@ def phillips_ouliaris(
     kernel: str = "bartlett",
     bandwidth: Optional[int] = None,
     force_int: bool = False,
-) -> "PhillipsOuliarisTestResults":
+) -> PhillipsOuliarisTestResults:
     r"""
     Test for cointegration within a set of time series.
 

--- a/arch/unitroot/_shared.py
+++ b/arch/unitroot/_shared.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any, Dict, NamedTuple, Optional, Tuple, Type
 
 import pandas as pd
@@ -219,7 +221,7 @@ class ResidualCointegrationTestResult(CointegrationTestResult):
 
     def plot(
         self, axes: Optional["plt.Axes"] = None, title: Optional[str] = None
-    ) -> "plt.Figure":
+    ) -> plt.Figure:
         """
         Plot the cointegration residuals.
 

--- a/arch/unitroot/cointegration.py
+++ b/arch/unitroot/cointegration.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import List, Optional, Sequence, Tuple
 
 import numpy as np

--- a/arch/unitroot/critical_values/dfgls.py
+++ b/arch/unitroot/critical_values/dfgls.py
@@ -5,6 +5,7 @@ statistics
 These have been computed using the methodology of MacKinnon (1994) and (2010)
 simulation. See dfgls_critival_values_simulation for implementation.
 """
+from __future__ import annotations
 
 from numpy import array
 

--- a/arch/unitroot/critical_values/dickey_fuller.py
+++ b/arch/unitroot/critical_values/dickey_fuller.py
@@ -6,6 +6,8 @@ Most values are from MacKinnon (1994) or (2010).  A small number of these
 did not appear in the original paper and have been computed using an identical
 simulation.
 """
+from __future__ import annotations
+
 from typing import Dict
 
 from numpy import array, asarray, inf

--- a/arch/unitroot/critical_values/engle_granger.py
+++ b/arch/unitroot/critical_values/engle_granger.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 
 eg_num_variables = np.arange(1, 13)

--- a/arch/unitroot/critical_values/kpss.py
+++ b/arch/unitroot/critical_values/kpss.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from numpy import asarray
 
 kpss_critical_values = {}

--- a/arch/unitroot/critical_values/phillips_ouliaris.py
+++ b/arch/unitroot/critical_values/phillips_ouliaris.py
@@ -10,6 +10,7 @@ P-type statistics with trend c based on 13,250,000 simulations
 P-type statistics with trend ct based on 11,250,000 simulations
 P-type statistics with trend ctt based on 13,250,000 simulations
 """
+from __future__ import annotations
 
 from math import inf
 

--- a/arch/unitroot/critical_values/simulation/adf_simulation.py
+++ b/arch/unitroot/critical_values/simulation/adf_simulation.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import os
 import platform
 import sys
-from typing import Optional, Union
+from typing import TYPE_CHECKING, Optional, Union
 
 from numpy import arange, array, cumsum, dot, ones, vstack
 from numpy.linalg import pinv
@@ -9,7 +11,7 @@ from numpy.random import Generator, RandomState
 
 if sys.version_info >= (3, 8):
     from typing import Literal
-else:
+elif TYPE_CHECKING:
     from typing_extensions import Literal
 
 # Storage Location

--- a/arch/unitroot/critical_values/simulation/adf_z_critical_values_simulation_joblib.py
+++ b/arch/unitroot/critical_values/simulation/adf_z_critical_values_simulation_joblib.py
@@ -1,15 +1,17 @@
 """
 Simulation of ADF z-test critical values.  Closely follows MacKinnon (2010).
 """
+from __future__ import annotations
+
 import argparse
 import os
 import random
 import sys
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 if sys.version_info >= (3, 8):
     from typing import Literal
-else:
+elif TYPE_CHECKING:
     from typing_extensions import Literal
 
 from adf_simulation import (

--- a/arch/unitroot/critical_values/simulation/adf_z_critical_values_simulation_large_cluster.py
+++ b/arch/unitroot/critical_values/simulation/adf_z_critical_values_simulation_large_cluster.py
@@ -10,10 +10,12 @@ Remote clusters can be used by modifying the Client initiation.
 This version has been optimized for execution on a large cluster and should
 scale well with 128 or more engines.
 """
+from __future__ import annotations
+
 import datetime
 import sys
 import time
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 from ipyparallel import Client, DirectView
 from numpy import array, nan, ndarray, percentile, savez
@@ -22,7 +24,7 @@ from .adf_simulation import adf_simulation
 
 if sys.version_info >= (3, 8):
     from typing import Literal
-else:
+elif TYPE_CHECKING:
     from typing_extensions import Literal
 
 # Time in seconds to sleep before checking if ready

--- a/arch/unitroot/critical_values/simulation/dfgls_critical_values_simulation.py
+++ b/arch/unitroot/critical_values/simulation/dfgls_critical_values_simulation.py
@@ -3,13 +3,15 @@ Critical value simulation for the Dickey-Fuller GLS model.  Similar in design
 to MacKinnon (2010).  Makes use of parallel_fun in statsmodels which works
 best when joblib is installed.
 """
+from __future__ import annotations
+
 import datetime
 import sys
-from typing import Optional, cast
+from typing import TYPE_CHECKING, Optional, cast
 
 if sys.version_info >= (3, 8):
     from typing import Literal
-else:
+elif TYPE_CHECKING:
     from typing_extensions import Literal
 
 import numpy as np

--- a/arch/unitroot/critical_values/zivot_andrews.py
+++ b/arch/unitroot/critical_values/zivot_andrews.py
@@ -7,6 +7,8 @@ Notes
 The p-values are generated through Monte Carlo simulation using 100,000
 replications and 2000 data points.
 """
+from __future__ import annotations
+
 from numpy import array
 
 # constant-only model

--- a/arch/unitroot/unitroot.py
+++ b/arch/unitroot/unitroot.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from abc import ABCMeta, abstractmethod
 from typing import Dict, List, Optional, Sequence, Tuple, Union
 import warnings
@@ -25,6 +27,7 @@ from numpy import (
     isnan,
     log,
     nan,
+    ndarray,
     ones,
     pi,
     polyval,
@@ -237,8 +240,8 @@ def _autolag_ols_low_memory(
     m = rhs.shape[1]
     xpx = empty((m + maxlag, m + maxlag)) * nan
     xpy = empty((m + maxlag, 1)) * nan
-    assert isinstance(xpx, NDArray)
-    assert isinstance(xpy, NDArray)
+    assert isinstance(xpx, ndarray)
+    assert isinstance(xpy, ndarray)
     xpy[:m] = rhs.T @ lhs
     xpx[:m, :m] = rhs.T @ rhs
     for i in range(maxlag):

--- a/arch/univariate/__init__.py
+++ b/arch/univariate/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from arch.univariate import recursions_python
 from arch.univariate.distribution import (
     Distribution,

--- a/arch/univariate/base.py
+++ b/arch/univariate/base.py
@@ -1,17 +1,30 @@
 """
 Core classes for ARCH models
 """
+from __future__ import annotations
+
 from abc import ABCMeta, abstractmethod
 from copy import deepcopy
 import datetime as dt
 import sys
-from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+    cast,
+)
 import warnings
 
-if sys.version_info < (3, 8):
-    from typing_extensions import Literal
-else:
+if sys.version_info >= (3, 8):
     from typing import Literal
+elif TYPE_CHECKING:
+    from typing_extensions import Literal
 
 import numpy as np
 import pandas as pd
@@ -309,9 +322,15 @@ class ARCHModel(object, metaclass=ABCMeta):
         raise NotImplementedError("Subclasses optionally may provide.")
 
     @abstractmethod
+    def _fit_no_arch_normal_errors_params(self) -> NDArray:
+        """
+        Must be overridden with closed form estimator the return parameters ony
+        """
+
+    @abstractmethod
     def _fit_no_arch_normal_errors(
         self, cov_type: Literal["robust", "classic"] = "robust"
-    ) -> "ARCHModelResult":
+    ) -> ARCHModelResult:
         """
         Must be overridden with closed form estimator
         """
@@ -329,7 +348,7 @@ class ARCHModel(object, metaclass=ABCMeta):
 
     def _fit_parameterless_model(
         self, cov_type: Literal["robust", "classic"], backcast: Union[float, NDArray]
-    ) -> "ARCHModelResult":
+    ) -> ARCHModelResult:
         """
         When models have no parameters, fill return values
 
@@ -441,7 +460,7 @@ class ARCHModel(object, metaclass=ABCMeta):
         params: Union[Sequence[float], ArrayLike1D],
         first_obs: Union[int, DateLike] = None,
         last_obs: Union[int, DateLike] = None,
-    ) -> "ARCHModelFixedResult":
+    ) -> ARCHModelFixedResult:
         """
         Allows an ARCHModelFixedResult to be constructed from fixed parameters.
 
@@ -539,7 +558,7 @@ class ARCHModel(object, metaclass=ABCMeta):
         tol: Optional[float] = None,
         options: Optional[Dict[str, Any]] = None,
         backcast: Optional[Union[float, NDArray]] = None,
-    ) -> "ARCHModelResult":
+    ) -> ARCHModelResult:
         r"""
         Fits the model given a nobs by 1 vector of sigma2 values
 
@@ -789,11 +808,7 @@ class ARCHModel(object, metaclass=ABCMeta):
         sv : ndarray
             Starting values
         """
-        params = np.asarray(self._fit_no_arch_normal_errors().params)
-        # Remove sigma2
-        if params.shape[0] == 1:
-            return np.empty(0)
-        return params[:-1]
+        return self._fit_no_arch_normal_errors_params()
 
     @cached_property
     @abstractmethod
@@ -900,7 +915,7 @@ class ARCHModel(object, metaclass=ABCMeta):
         simulations: int = 1000,
         rng: Optional[Callable[[Union[int, Tuple[int, ...]]], NDArray]] = None,
         random_state: Optional[np.random.RandomState] = None,
-    ) -> "ARCHModelForecast":
+    ) -> ARCHModelForecast:
         """
         Construct forecasts from estimated model
 
@@ -1242,7 +1257,7 @@ class ARCHModelFixedResult(_SummaryRepr):
 
     def plot(
         self, annualize: Optional[str] = None, scale: Optional[float] = None
-    ) -> "Figure":
+    ) -> Figure:
         """
         Plot standardized residuals and conditional volatility
 
@@ -1329,7 +1344,7 @@ class ARCHModelFixedResult(_SummaryRepr):
         simulations: int = 1000,
         rng: Optional[Callable[[Union[int, Tuple[int, ...]]], NDArray]] = None,
         random_state: Optional[np.random.RandomState] = None,
-    ) -> "ARCHModelForecast":
+    ) -> ARCHModelForecast:
         """
         Construct forecasts from estimated model
 
@@ -1420,7 +1435,7 @@ class ARCHModelFixedResult(_SummaryRepr):
         plot_type: str = "volatility",
         method: str = "analytic",
         simulations: int = 1000,
-    ) -> "Figure":
+    ) -> Figure:
         """
         Plot forecasts from estimated model
 

--- a/arch/univariate/distribution.py
+++ b/arch/univariate/distribution.py
@@ -3,6 +3,8 @@
 Distributions to use in ARCH models.  All distributions must inherit from
 :class:`Distribution` and provide the same methods with the same inputs.
 """
+from __future__ import annotations
+
 from abc import ABCMeta, abstractmethod
 from typing import Callable, List, Optional, Sequence, Tuple, Union
 

--- a/arch/univariate/recursions_python.py
+++ b/arch/univariate/recursions_python.py
@@ -3,6 +3,8 @@ Pure Python implementations of the core recursions in the models. Only used for
 testing and if it is not possible to install the Cython version using
 python setup.py install --no-binary
 """
+from __future__ import annotations
+
 from arch.compat.numba import jit
 
 import numpy as np
@@ -20,7 +22,7 @@ __all__ = [
     "aparch_recursion",
 ]
 
-LNSIGMA_MAX = np.log(np.finfo(np.double).max) - 0.1
+LNSIGMA_MAX = float(np.log(np.finfo(np.double).max) - 0.1)
 
 
 def bounds_check_python(sigma2: float, var_bounds: NDArray) -> float:

--- a/arch/utility/array.py
+++ b/arch/utility/array.py
@@ -1,6 +1,8 @@
 """
 Utility functions that do not explicitly relate to Volatility modeling
 """
+from __future__ import annotations
+
 from arch.compat.pandas import is_datetime64_any_dtype
 
 from abc import ABCMeta

--- a/arch/utility/cov.py
+++ b/arch/utility/cov.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Union
 
 from numpy import asarray

--- a/arch/utility/io.py
+++ b/arch/utility/io.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 
 __all__ = ["str_format", "pval_format"]

--- a/arch/utility/testing.py
+++ b/arch/utility/testing.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Dict
 
 from scipy.stats import chi2

--- a/arch/utility/timeseries.py
+++ b/arch/utility/timeseries.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Optional, Sequence, Tuple
 
 import numpy as np


### PR DESCRIPTION
Remove dependence on Python 3.7