### PR TITLE
ENH: Improve lag length selection in DFGLS

### DIFF
--- a/doc/source/changes/5.0.txt
+++ b/doc/source/changes/5.0.txt
@@ -2,6 +2,16 @@
 Version 5
 =========
 
+Release 5.1
+===========
+
+Unit Root
+~~~~~~~~~
+
+- Improved automatic lag length selection in :class:`~arch.unitroot.DFGLS`
+  by using OLS rather than GLS detrended data when selecting the lag length.
+  This problem was studied by Perron, P., & Qu, Z. (2007).
+
 Release 5.0
 ===========
 


### PR DESCRIPTION
Improve lag length method in DFGLS to use OLS rather than
GLS which has poor power far from null