### PR TITLE
BUG: Allow NumPy arrays in univariate models

### DIFF
--- a/arch/tests/univariate/test_mean.py
+++ b/arch/tests/univariate/test_mean.py
@@ -1321,3 +1321,15 @@ def test_last_obs_equiv_param(first, last, mean):
     assert_allclose(res1.model._backcast, res2.model._backcast, rtol=RTOL)
     assert_allclose(res1.params, res2.params, rtol=RTOL)
     assert_allclose(cv1[np.isfinite(cv1)], cv2[np.isfinite(cv2)], rtol=RTOL)
+
+
+@pytest.mark.parametrize("use_pandas", [True, False])
+def test_all_attr_numpy_pandas(use_pandas):
+    data = SP500
+    if not use_pandas:
+        data = np.asanyarray(data)
+    mod = arch_model(data, p=1, o=1, q=1)
+    res = mod.fit(disp="off")
+    for attr in dir(res):
+        if not attr.startswith("_"):
+            getattr(res, attr)

--- a/arch/univariate/base.py
+++ b/arch/univariate/base.py
@@ -1300,7 +1300,8 @@ class ARCHModelFixedResult(_SummaryRepr):
         Residuals standardized by conditional volatility
         """
         std_res = self.resid / self.conditional_volatility
-        std_res.name = "std_resid"
+        if isinstance(std_res, pd.Series):
+            std_res.name = "std_resid"
         return std_res
 
     def plot(

--- a/doc/source/changes/5.0.txt
+++ b/doc/source/changes/5.0.txt
@@ -4,7 +4,10 @@ Version 5
 
 Since 5.1
 =========
-- Fix a bug in :func:`~arch.univariate.base.ARCHModelResult.forecast` and related
+- Fixed a bug in in :func:`~arch.univariate.base.ARCHModelResult.std_resid` that
+  would raise an exception when the data used to construct the model with a NumPy
+  array (:issue:`565`).
+- Fixed a bug in :func:`~arch.univariate.base.ARCHModelResult.forecast` and related
   ``forecast`` methods when producing multi-step forecasts usign simulation with
   exogenous variables (:issue:`551`).
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,7 +14,7 @@ pytest>=5
 pytest-xdist
 
 # formatting
-black[jupyter]==22.1.0
+black[jupyter]==22.3.0
 isort
 flake8
 


### PR DESCRIPTION
Only set name when using pandas

closes #565