### PR TITLE
fix(sec): upgrade ipython to 8.0.1

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -5,7 +5,7 @@ oldest-supported-numpy
 Cython>=0.29.24
 numpy >=1.22
 scipy >=1.3.2
-ipython >=7
+ipython >=8.0.1
 matplotlib >=3.0
 pandas >=1.0.3
 patsy >=0.5.1


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in ipython 7
- [CVE-2022-21699](https://www.oscs1024.com/hd/CVE-2022-21699)


### What did I do？
Upgrade ipython from 7 to 8.0.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS