### PR TITLE
prefer `functools.cached_property` for python >= 3.8

### DIFF
--- a/arch/vendor/__init__.py
+++ b/arch/vendor/__init__.py
@@ -1,7 +1,14 @@
-try:
-    # Prefer system installed version if available
-    from property_cached import cached_property
-except ImportError:
-    from arch.vendor.property_cached import cached_property
+import sys
+
+if sys.version_info >= (3, 8):
+    from functools import cached_property
+else:
+    try:
+        # Prefer system installed version if available
+        from property_cached import cached_property
+    except ImportError:
+        from arch.vendor.property_cached import cached_property
+
 
 __all__ = ["cached_property"]
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ numpy>=1.17
 scipy>=1.3
 pandas>=1.0
 statsmodels>=0.11
-property_cached>=1.6.4
+


### PR DESCRIPTION
and removed the required dependency on `property_cached`, since it's optional, and only required for Python 3.7