### PR TITLE
MAINT: Rollback Cython to 0.29 branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ ahead-of-time compiled extensions.
 
 The development requirements are:
 
-- Cython (0.29+, if not using ARCH_NO_BINARY=1)
+- Cython (0.29+, if not using ARCH_NO_BINARY=1, supports 3.0.0b2+)
 - pytest (For tests)
 - sphinx (to build docs)
 - sphinx-immaterial (to build docs)

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -2,7 +2,7 @@ setuptools>=61
 wheel
 setuptools_scm[toml]>=7,<8
 oldest-supported-numpy
-cython>=3.0.0b2
+cython>=0.29.34  # Works with 3.0.0b2
 numpy >=1.22
 scipy >=1.5.0
 ipython >=8.0.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [
   "setuptools_scm[toml]>=7,<8",
   "oldest-supported-numpy>=2022.11.19",
   "numpy; python_version>='3.12'",
-  "cython>=3.0.0b2"
+  "cython>=0.29.34"  # Works with 3.0.0b2
 ]
 build-backend = "setuptools.build_meta"
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,7 @@ packaging
 oldest-supported-numpy>=2022.11.19
 
 # Performance
-cython>=3.0.0b2
+cython>=0.29.34  # Works with 3.0.0b2
 numba>=0.49,!=0.50.*
 
 # Graphics


### PR DESCRIPTION
Rollback to get conda-forge to work on release 6 branch