### PR TITLE
Fixed deprecation warning

### DIFF
--- a/arch/tests/univariate/test_forecast.py
+++ b/arch/tests/univariate/test_forecast.py
@@ -766,8 +766,8 @@ def test_x_forecasting(nexog):
     direct = np.zeros(12)
     direct[:2] = y.iloc[-2:]
     p0, p1, p2 = res.params[:3]
-    b0 = res.params[3]
-    b1 = res.params[4] if x.shape[1] == 2 else 0.0
+    b0 = np.asarray(res.params)[3]
+    b1 = np.asarray(res.params)[4] if x.shape[1] == 2 else 0.0
     for i in range(10):
         direct[i + 2] = p0 + p1 * direct[i + 1] + p2 * direct[i]
         direct[i + 2] += b0 * (i)

--- a/arch/tests/univariate/test_forecast.py
+++ b/arch/tests/univariate/test_forecast.py
@@ -765,9 +765,9 @@ def test_x_forecasting(nexog):
     forecasts = res.forecast(x=x_fcast, horizon=10)
     direct = np.zeros(12)
     direct[:2] = y.iloc[-2:]
-    p0, p1, p2 = res.params[:3]
-    b0 = np.asarray(res.params)[3]
-    b1 = np.asarray(res.params)[4] if x.shape[1] == 2 else 0.0
+    p0, p1, p2, *bs = res.params
+    b0 = bs[0]
+    b1 = bs[1] if x.shape[1] == 2 else 0.0
     for i in range(10):
         direct[i + 2] = p0 + p1 * direct[i + 1] + p2 * direct[i]
         direct[i + 2] += b0 * (i)

--- a/arch/tests/univariate/test_mean.py
+++ b/arch/tests/univariate/test_mean.py
@@ -463,7 +463,8 @@ class TestMeanModel:
         ar = ARX(self.y, lags=0)
         assert ar.lags is None
         res = ar.fit(disp=DISPLAY)
-        assert_almost_equal(np.asarray(res.params)[0], self.y.mean())
+        param0, *_ = res.params
+        assert_almost_equal(param0, self.y.mean())
         assert "lags: none" in ar.__str__()
 
     @pytest.mark.skipif(not HAS_MATPLOTLIB, reason="matplotlib not installed")

--- a/arch/tests/univariate/test_mean.py
+++ b/arch/tests/univariate/test_mean.py
@@ -463,7 +463,7 @@ class TestMeanModel:
         ar = ARX(self.y, lags=0)
         assert ar.lags is None
         res = ar.fit(disp=DISPLAY)
-        assert_almost_equal(res.params[0], self.y.mean())
+        assert_almost_equal(np.asarray(res.params)[0], self.y.mean())
         assert "lags: none" in ar.__str__()
 
     @pytest.mark.skipif(not HAS_MATPLOTLIB, reason="matplotlib not installed")

--- a/arch/tests/univariate/test_rescale.py
+++ b/arch/tests/univariate/test_rescale.py
@@ -39,7 +39,12 @@ def test_blank(small_data, std_data):
     small_res = small_mod.fit(starting_values=np.array([1e-3, 0.05, 0.90]), disp="off")
     mod = ZeroMean(std_data, volatility=GARCH(), rescale=False)
     res = mod.fit(starting_values=np.array([1, 0.05, 0.90]), disp="off")
-    assert_allclose(1e3 * small_res.params[0], res.params[0], rtol=5e-3, atol=1e9)
+    assert_allclose(
+        1e3 * np.asarray(small_res.params)[0],
+        np.asarray(res.params)[0],
+        rtol=5e-3,
+        atol=1e9,
+    )
 
 
 def test_rescale_fit(small_data, std_data):

--- a/arch/tests/univariate/test_rescale.py
+++ b/arch/tests/univariate/test_rescale.py
@@ -39,12 +39,10 @@ def test_blank(small_data, std_data):
     small_res = small_mod.fit(starting_values=np.array([1e-3, 0.05, 0.90]), disp="off")
     mod = ZeroMean(std_data, volatility=GARCH(), rescale=False)
     res = mod.fit(starting_values=np.array([1, 0.05, 0.90]), disp="off")
-    assert_allclose(
-        1e3 * np.asarray(small_res.params)[0],
-        np.asarray(res.params)[0],
-        rtol=5e-3,
-        atol=1e9,
-    )
+    
+    small_param0, *_ = small_res.params
+    param0, *_ = res.params
+    assert_allclose(1e3 * small_param0, param0, rtol=5e-3, atol=1e9)
 
 
 def test_rescale_fit(small_data, std_data):

--- a/arch/tests/univariate/test_rescale.py
+++ b/arch/tests/univariate/test_rescale.py
@@ -39,7 +39,7 @@ def test_blank(small_data, std_data):
     small_res = small_mod.fit(starting_values=np.array([1e-3, 0.05, 0.90]), disp="off")
     mod = ZeroMean(std_data, volatility=GARCH(), rescale=False)
     res = mod.fit(starting_values=np.array([1, 0.05, 0.90]), disp="off")
-    
+
     small_param0, *_ = small_res.params
     param0, *_ = res.params
     assert_allclose(1e3 * small_param0, param0, rtol=5e-3, atol=1e9)

--- a/arch/unitroot/_engle_granger.py
+++ b/arch/unitroot/_engle_granger.py
@@ -192,7 +192,7 @@ class EngleGrangerTestResults(ResidualCointegrationTestResult):
                          + \epsilon_t
         """
 
-        return 1 + self._adf.regression.params[0]
+        return 1 + np.asarray(self._adf.regression.params)[0]
 
     def summary(self) -> Summary:
         """Summary of test, containing statistic, p-value and critical values"""

--- a/arch/unitroot/_engle_granger.py
+++ b/arch/unitroot/_engle_granger.py
@@ -192,7 +192,8 @@ class EngleGrangerTestResults(ResidualCointegrationTestResult):
                          + \epsilon_t
         """
 
-        return 1 + np.asarray(self._adf.regression.params)[0]
+        param0, *_ = self._adf.regression.params
+        return 1 + param0
 
     def summary(self) -> Summary:
         """Summary of test, containing statistic, p-value and critical values"""

--- a/arch/unitroot/unitroot.py
+++ b/arch/unitroot/unitroot.py
@@ -782,7 +782,7 @@ class ADF(UnitRootTest, metaclass=AbstractDocStringInheritor):
         y, trend, lags = self._y, self._trend, self._lags
         resols = _estimate_df_regression(y, cast(UnitRootTrend, trend), lags)
         self._regression = resols
-        self._stat = stat = np.asarray(resols.tvalues)[0]
+        self._stat = stat = asarray(resols.tvalues)[0]
         self._nobs = int(resols.nobs)
         self._pvalue = mackinnonp(
             stat,
@@ -952,7 +952,7 @@ class DFGLS(UnitRootTest, metaclass=AbstractDocStringInheritor):
         resols = _estimate_df_regression(y_detrended, lags=lags, trend="n")
         self._regression = resols
         self._nobs = int(resols.nobs)
-        self._stat = np.asarray(resols.tvalues)[0]
+        self._stat = asarray(resols.tvalues)[0]
         assert self._stat is not None
         self._pvalue = mackinnonp(
             self._stat, regression=cast(Literal["c", "ct"], trend), dist_type="dfgls"
@@ -1131,7 +1131,7 @@ class PhillipsPerron(UnitRootTest, metaclass=AbstractDocStringInheritor):
         s2 = u @ u / (n - k)
         s = sqrt(s2)
         gamma0 = s2 * (n - k) / n
-        sigma = np.asarray(resols.bse)[0]
+        sigma = asarray(resols.bse)[0]
         sigma2 = sigma**2.0
         if sigma <= 0:
             raise InfeasibleTestException(
@@ -1139,7 +1139,7 @@ class PhillipsPerron(UnitRootTest, metaclass=AbstractDocStringInheritor):
                 "regression is 0. This may occur if the series contains constant "
                 "values or the residual variance in the regression is 0."
             )
-        rho = np.asarray(resols.params)[0]
+        rho = asarray(resols.params)[0]
         # 3. Compute statistics
         self._stat_tau = sqrt(gamma0 / lam2) * ((rho - 1) / sigma) - 0.5 * (
             (lam2 - gamma0) / lam

--- a/arch/unitroot/unitroot.py
+++ b/arch/unitroot/unitroot.py
@@ -782,7 +782,7 @@ class ADF(UnitRootTest, metaclass=AbstractDocStringInheritor):
         y, trend, lags = self._y, self._trend, self._lags
         resols = _estimate_df_regression(y, cast(UnitRootTrend, trend), lags)
         self._regression = resols
-        self._stat = stat = resols.tvalues[0]
+        self._stat = stat = np.asarray(resols.tvalues)[0]
         self._nobs = int(resols.nobs)
         self._pvalue = mackinnonp(
             stat,
@@ -952,7 +952,7 @@ class DFGLS(UnitRootTest, metaclass=AbstractDocStringInheritor):
         resols = _estimate_df_regression(y_detrended, lags=lags, trend="n")
         self._regression = resols
         self._nobs = int(resols.nobs)
-        self._stat = resols.tvalues[0]
+        self._stat = np.asarray(resols.tvalues)[0]
         assert self._stat is not None
         self._pvalue = mackinnonp(
             self._stat, regression=cast(Literal["c", "ct"], trend), dist_type="dfgls"
@@ -1131,7 +1131,7 @@ class PhillipsPerron(UnitRootTest, metaclass=AbstractDocStringInheritor):
         s2 = u @ u / (n - k)
         s = sqrt(s2)
         gamma0 = s2 * (n - k) / n
-        sigma = resols.bse[0]
+        sigma = np.asarray(resols.bse)[0]
         sigma2 = sigma**2.0
         if sigma <= 0:
             raise InfeasibleTestException(
@@ -1139,7 +1139,7 @@ class PhillipsPerron(UnitRootTest, metaclass=AbstractDocStringInheritor):
                 "regression is 0. This may occur if the series contains constant "
                 "values or the residual variance in the regression is 0."
             )
-        rho = resols.params[0]
+        rho = np.asarray(resols.params)[0]
         # 3. Compute statistics
         self._stat_tau = sqrt(gamma0 / lam2) * ((rho - 1) / sigma) - 0.5 * (
             (lam2 - gamma0) / lam

--- a/arch/unitroot/unitroot.py
+++ b/arch/unitroot/unitroot.py
@@ -782,7 +782,7 @@ class ADF(UnitRootTest, metaclass=AbstractDocStringInheritor):
         y, trend, lags = self._y, self._trend, self._lags
         resols = _estimate_df_regression(y, cast(UnitRootTrend, trend), lags)
         self._regression = resols
-        self._stat = stat = asarray(resols.tvalues)[0]
+        (self._stat, *_) = (stat, *_) = resols.tvalues
         self._nobs = int(resols.nobs)
         self._pvalue = mackinnonp(
             stat,
@@ -952,7 +952,7 @@ class DFGLS(UnitRootTest, metaclass=AbstractDocStringInheritor):
         resols = _estimate_df_regression(y_detrended, lags=lags, trend="n")
         self._regression = resols
         self._nobs = int(resols.nobs)
-        self._stat = asarray(resols.tvalues)[0]
+        self._stat, *_ = resols.tvalues
         assert self._stat is not None
         self._pvalue = mackinnonp(
             self._stat, regression=cast(Literal["c", "ct"], trend), dist_type="dfgls"
@@ -1131,7 +1131,7 @@ class PhillipsPerron(UnitRootTest, metaclass=AbstractDocStringInheritor):
         s2 = u @ u / (n - k)
         s = sqrt(s2)
         gamma0 = s2 * (n - k) / n
-        sigma = asarray(resols.bse)[0]
+        sigma, *_ = resols.bse
         sigma2 = sigma**2.0
         if sigma <= 0:
             raise InfeasibleTestException(
@@ -1139,7 +1139,7 @@ class PhillipsPerron(UnitRootTest, metaclass=AbstractDocStringInheritor):
                 "regression is 0. This may occur if the series contains constant "
                 "values or the residual variance in the regression is 0."
             )
-        rho = asarray(resols.params)[0]
+        rho, *_ = resols.params
         # 3. Compute statistics
         self._stat_tau = sqrt(gamma0 / lam2) * ((rho - 1) / sigma) - 0.5 * (
             (lam2 - gamma0) / lam

--- a/arch/univariate/base.py
+++ b/arch/univariate/base.py
@@ -1189,7 +1189,7 @@ class ARCHModelFixedResult(_SummaryRepr):
 
         stubs = list(self._names)
         header = ["coef"]
-        coef_vals = (self.params,)
+        coef_vals = (np.asarray(self.params),)
         formats = [(10, 4)]
         pos = 0
         param_table_data = []
@@ -1887,11 +1887,12 @@ class ARCHModelResult(ARCHModelFixedResult):
         for _ in range(len(table_vals[0])):
             row = []
             for i, table_val in enumerate(table_vals):
-                if isinstance(table_val[pos], (np.float64, float)):
-                    assert isinstance(table_val[pos], float)
-                    converted = format_float_fixed(table_val[pos], *formats[i])
+                val = np.asarray(table_val)[pos]
+                if isinstance(val, (np.float64, float)):
+                    assert isinstance(val, float)
+                    converted = format_float_fixed(val, *formats[i])
                 else:
-                    converted = table_val[pos]
+                    converted = val
                 row.append(converted)
             pos += 1
             param_table_data.append(row)

--- a/arch/univariate/base.py
+++ b/arch/univariate/base.py
@@ -1189,16 +1189,10 @@ class ARCHModelFixedResult(_SummaryRepr):
 
         stubs = list(self._names)
         header = ["coef"]
-        coef_vals = (np.asarray(self.params),)
-        formats = [(10, 4)]
-        pos = 0
-        param_table_data = []
-        for _ in range(len(coef_vals[0])):
-            row = []
-            for i, coef_val in enumerate(coef_vals):
-                row.append(format_float_fixed(coef_val[pos], *formats[i]))
-            pos += 1
-            param_table_data.append(row)
+        param_table_data = [
+            [format_float_fixed(param, 10, 4)]
+            for param in self.params
+        ]
 
         mc = self.model.num_params
         vc = self.model.volatility.num_params
@@ -1874,27 +1868,24 @@ class ARCHModelResult(ARCHModelFixedResult):
         stubs = list(self._names)
         header = ["coef", "std err", "t", "P>|t|", "95.0% Conf. Int."]
         table_vals = (
-            self.params,
-            self.std_err,
-            self.tvalues,
-            self.pvalues,
+            np.asarray(self.params),
+            np.asarray(self.std_err),
+            np.asarray(self.tvalues),
+            np.asarray(self.pvalues),
             pd.Series(conf_int_str),
         )
         # (0,0) is a dummy format
         formats = [(10, 4), (9, 3), (9, 3), (9, 3), (0, 0)]
-        pos = 0
         param_table_data = []
-        for _ in range(len(table_vals[0])):
+        for pos in range(len(table_vals[0])):
             row = []
             for i, table_val in enumerate(table_vals):
-                val = np.asarray(table_val)[pos]
+                val = table_val[pos]
                 if isinstance(val, (np.float64, float)):
-                    assert isinstance(val, float)
                     converted = format_float_fixed(val, *formats[i])
                 else:
                     converted = val
                 row.append(converted)
-            pos += 1
             param_table_data.append(row)
 
         mc = self.model.num_params


### PR DESCRIPTION
This fixes several cases of:

```
FutureWarning: Series.__getitem__ treating keys as positions is deprecated. In a future version, integer keys will always be treated as labels (consistent with DataFrame behavior). To access a value by position, use `ser.iloc[pos]`
```