### PR TITLE
Sped up covariance estimate via numba

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -29,6 +29,8 @@ exclude_lines =
     cdef
     # Cython functions with void
     cdef void
+    # Numba jit decorators
+    @jit
 
 
 include = */arch/*

--- a/arch/compat/numba.py
+++ b/arch/compat/numba.py
@@ -1,6 +1,6 @@
 import functools
 import os
-from typing import Any, Callable, Optional
+from typing import Any, Callable
 
 from arch.utility.exceptions import PerformanceWarning
 
@@ -22,17 +22,20 @@ try:
 except ImportError:
 
     def jit(
-        func: Optional[Callable[..., Any]],
         *args: Any,
         **kwargs: Any,
     ) -> Any:
-        def wrapper(*args: Any, **kwargs: Any) -> Callable[..., Any]:
-            import warnings
+        def wrap(func):
+            @functools.wraps(func)
+            def wrapper(*args: Any, **kwargs: Any) -> Callable[..., Any]:
+                import warnings
 
-            warnings.warn(performance_warning, PerformanceWarning)
-            return func(*args, **kwargs)
+                warnings.warn(performance_warning, PerformanceWarning)
+                return func(*args, **kwargs)
 
-        return wrapper
+            return wrapper
+
+        return wrap
 
 
 __all__ = ["jit", "PerformanceWarning"]

--- a/arch/compat/numba.py
+++ b/arch/compat/numba.py
@@ -1,11 +1,10 @@
 import functools
 import os
-from typing import Any, Callable
+from typing import Any, Callable, Optional
 
 from arch.utility.exceptions import PerformanceWarning
 
 DISABLE_NUMBA = os.environ.get("ARCH_DISABLE_NUMBA", False) in ("1", "true", "True")
-
 
 performance_warning: str = """
 numba is not available, and this function is being executed without JIT
@@ -22,7 +21,11 @@ try:
 
 except ImportError:
 
-    def jit(func: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+    def jit(
+        func: Optional[Callable[..., Any]],
+        *args: Any,
+        **kwargs: Any,
+    ) -> Any:
         def wrapper(*args: Any, **kwargs: Any) -> Callable[..., Any]:
             import warnings
 

--- a/arch/compat/numba.py
+++ b/arch/compat/numba.py
@@ -1,6 +1,6 @@
 import functools
 import os
-from typing import Any, Callable
+from typing import Any, Callable, Optional
 
 from arch.utility.exceptions import PerformanceWarning
 
@@ -22,9 +22,13 @@ try:
 except ImportError:
 
     def jit(
+        function_or_signature: Optional[Callable[..., Any]] = None,
         *args: Any,
         **kwargs: Any,
     ) -> Any:
+        if function_or_signature is not None and callable(function_or_signature):
+            return function_or_signature
+
         def wrap(func):
             @functools.wraps(func)
             def wrapper(*args: Any, **kwargs: Any) -> Callable[..., Any]:

--- a/arch/covariance/kernel.py
+++ b/arch/covariance/kernel.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from arch.compat.numba import jit
+
 from abc import ABC, abstractmethod
 from functools import cached_property
 from typing import SupportsInt, cast
@@ -8,7 +10,6 @@ import numpy as np
 from pandas import DataFrame, Index
 from pandas.util._decorators import Substitution
 
-from arch.compat.numba import jit
 from arch.typing import ArrayLike, Float64Array
 from arch.utility.array import AbstractDocStringInheritor, ensure1d, ensure2d
 

--- a/arch/covariance/kernel.py
+++ b/arch/covariance/kernel.py
@@ -140,6 +140,7 @@ class CovarianceEstimate:
 @jit(nopython=True)
 def _cov_jit(df, k, num_weights, w, x):
     oss = np.zeros((k, k))
+    x = np.ascontiguousarray(x)
     for i in range(1, num_weights):
         oss += w[i] * (x[i:].T @ x[:-i]) / df
     return oss

--- a/arch/covariance/kernel.py
+++ b/arch/covariance/kernel.py
@@ -140,7 +140,6 @@ class CovarianceEstimate:
 @jit(nopython=True)
 def _cov_jit(df, k, num_weights, w, x):
     oss = np.zeros((k, k))
-    x = np.ascontiguousarray(x)
     for i in range(1, num_weights):
         oss += w[i] * (x[i:].T @ x[:-i]) / df
     return oss
@@ -402,7 +401,7 @@ class CovarianceEstimator(ABC):
         --------
         CovarianceEstimate
         """
-        x = np.asarray(self._x)
+        x = np.ascontiguousarray(self._x)
         k = x.shape[1]
         df = self._df
         sr = x.T @ x / df


### PR DESCRIPTION
Benchmarked using: `py.test arch/tests/unitroot/test_fmols_ccr.py`

Before:
```bash
============================= fixture duration top ============================== 
total          name              num   avg            min
0:00:00.080000             trend  1728        0:00:00 0:00:00
0:00:00.062000              diff  1728        0:00:00 0:00:00
0:00:00.032000            kernel  1728        0:00:00 0:00:00
0:00:00.031000         force_int  1728        0:00:00 0:00:00
0:00:00.016000   trivariate_data     2 0:00:00.008000 0:00:00
0:00:00.016000           x_trend  1728        0:00:00 0:00:00
0:00:00.016000         bandwidth  1728        0:00:00 0:00:00
0:00:00.253000       grand total 10426        0:00:00 0:00:00
============================ test call duration top ============================= 
total          name              num   avg            min
0:00:06.062000  test_fmols_smoke   864        0:00:00 0:00:00
0:00:06.001000    test_ccr_smoke   864        0:00:00 0:00:00
0:00:00.093000   test_ccr_eviews    26        0:00:00 0:00:00
0:00:00.078000 test_fmols_eviews    26        0:00:00 0:00:00
0:00:12.234000       grand total  1784        0:00:00 0:00:00
============================ test setup duration top ============================ 
total          name              num   avg            min
0:00:00.377000  test_fmols_smoke   864        0:00:00 0:00:00
0:00:00.295000    test_ccr_smoke   864        0:00:00 0:00:00
0:00:00.672000       grand total  1784        0:00:00 0:00:00
========================== test teardown duration top =========================== 
total          name              num   avg            min
0:00:00.142000  test_fmols_smoke   864        0:00:00 0:00:00
0:00:00.124000    test_ccr_smoke   864        0:00:00 0:00:00
0:00:00.266000       grand total  1784        0:00:00 0:00:00
============================= 1784 passed in 14.37s ============================= 
```

After:
```
============================= fixture duration top ============================== 
total          name              num   avg            min
0:00:00.063000             trend  1728        0:00:00 0:00:00
0:00:00.048000           x_trend  1728        0:00:00 0:00:00
0:00:00.032000         force_int  1728        0:00:00 0:00:00
0:00:00.016000   trivariate_data     2 0:00:00.008000 0:00:00
0:00:00.016000            kernel  1728        0:00:00 0:00:00
0:00:00.015000         bandwidth  1728        0:00:00 0:00:00
0:00:00.190000       grand total 10426        0:00:00 0:00:00
============================ test call duration top ============================= 
total          name              num   avg            min
0:00:04.528000  test_fmols_smoke   864        0:00:00 0:00:00
0:00:03.748000    test_ccr_smoke   864        0:00:00 0:00:00
0:00:00.094000 test_fmols_eviews    26        0:00:00 0:00:00
0:00:00.094000   test_ccr_eviews    26        0:00:00 0:00:00
0:00:08.464000       grand total  1784        0:00:00 0:00:00
============================ test setup duration top ============================ 
total          name              num   avg            min
0:00:00.392000    test_ccr_smoke   864        0:00:00 0:00:00
0:00:00.329000  test_fmols_smoke   864        0:00:00 0:00:00
0:00:00.721000       grand total  1784        0:00:00 0:00:00
========================== test teardown duration top =========================== 
total          name              num   avg            min
0:00:00.109000  test_fmols_smoke   864        0:00:00 0:00:00
0:00:00.064000    test_ccr_smoke   864        0:00:00 0:00:00
0:00:00.016000   test_ccr_eviews    26        0:00:00 0:00:00
0:00:00.189000       grand total  1784        0:00:00 0:00:00
============================= 1784 passed in 10.34s ============================= 
```

Nothing too dramatic but a useful performance improvement :)

I'm still looking at other bottlenecks right now so depending on your preference I can create separate pull requests or a single large one :)