### PR TITLE
bugfix FIGARCH(1, d, 1) formula in the function description

### DIFF
--- a/arch/univariate/volatility.py
+++ b/arch/univariate/volatility.py
@@ -2962,7 +2962,7 @@ class FIGARCH(VolatilityProcess, metaclass=AbstractDocStringInheritor):
 
     .. math::
 
-        h_t = \omega + [1-\beta L - \phi L  (1-L)^d] \epsilon_t^2 + \beta h_{t-1}
+        h_t = \omega + [1-\beta L - (1-\phi L)  (1-L)^d] \epsilon_t^2 + \beta h_{t-1}
 
     where ``L`` is the lag operator and ``d`` is the fractional differencing
     parameter. The model is estimated using the ARCH(:math:`\infty`)


### PR DESCRIPTION
E.g. in the original paper of Baililie et al. / Journal of Econometrics 74 (1996) 3-30 at the top o p.14 in the table caption:

$\sigma_t^2 = \omega + [1 - \beta L - (1 - \phi L)(1 - L)^d] R_t^2 + \beta \sigma_{t-1}^2$

so $\phi(L)=1-\phi L$ for first order model.

In ARCH($\infty$) form: 
 
$\sigma_t^2 = (1 - \beta(L))^{-1} \omega + \lambda(L) R_t^2$ 

where

$\lambda(L) = (1 - (1 - \beta L)^{-1} (1 - \phi L)(1 - L)^d) = \sum_{k=0}^\infty \lambda_k L^k$

Having $1-\phi L$ is necessary for $\lambda_0$ to be 0, as is correctly written in the recursive formulas.