### PR TITLE
Add MAMean (MA(q)) model with volatility & forecasting support

### DIFF
--- a/arch/univariate/__init__.py
+++ b/arch/univariate/__init__.py
@@ -15,6 +15,7 @@ from arch.univariate.mean import (
     ARCHInMean,
     ConstantMean,
     ZeroMean,
+    MAMean,
     arch_model,
 )
 from arch.univariate.volatility import (
@@ -43,6 +44,7 @@ __all__ = [
     "ARCHInMean",
     "ARX",
     "ConstantMean",
+    "MAMean",
     "ConstantVariance",
     "Distribution",
     "EGARCH",


### PR DESCRIPTION
This PR introduces an implementation of the Moving Average (MA) mean model—`MAMean`—as a new subclass of `ARCHModel`.  
It fills a longstanding gap in ARCH’s mean model suite, enabling direct modeling of MA(q) dynamics in return series.

---

## Key Features

- **New Model:** `MAMean`, supporting flexible lag order `q`, with optional constant term.
-**API:** `.fit()`, `.simulate()`, `.forecast()`, `.resids`
-**Volatility support:** Tested with `GARCH(1,1)` (others welcome)
- **Public API Ready:** Registered via `__init__.py` and `__all__`

---

## 🧪 Testing

-  **Tested pipeline:** `MAMean` + `GARCH(1,1)`:
  - Smoke‑tested simulation, forecasting, and residual pipelines.
- **Coverage :**
  - Parameter handling (lags, bounds)
  - Simulation pipeline
  - Forecast integration

---

## 📝 Notes

- 🔍 Currently validated only against `GARCH(1,1)`   and Future tests with EGARCH, APARCH is encouraged
- 📐 Design mirrors `ARX`/`HARX`, making future extensions trivial
- 🙌 Happy to iterate on interface, test depth, or documentation if requested

