### PR TITLE
Raise upper bound on setuptools-scm from 9 to 9.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ changelog = "https://bashtage.github.io/arch/changes.html"
 requires = [
   "setuptools>=61",
   "wheel",
-  "setuptools_scm>=8.0.3,<9.3",
+  "setuptools_scm>=9.0.0,<10",
   "cython>=3.0.10",
   "numpy>=2.0.0rc1,<3"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ changelog = "https://bashtage.github.io/arch/changes.html"
 requires = [
   "setuptools>=61",
   "wheel",
-  "setuptools_scm>=9.0.0,<10",
+  "setuptools_scm>=9.0.3,<10",
   "cython>=3.0.10",
   "numpy>=2.0.0rc1,<3"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ changelog = "https://bashtage.github.io/arch/changes.html"
 requires = [
   "setuptools>=61",
   "wheel",
-  "setuptools_scm[toml]>=8.0.3,<9.3",
+  "setuptools_scm>=8.0.3,<9.3",
   "cython>=3.0.10",
   "numpy>=2.0.0rc1,<3"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ changelog = "https://bashtage.github.io/arch/changes.html"
 requires = [
   "setuptools>=61",
   "wheel",
-  "setuptools_scm[toml]>=8.0.3,<9",
+  "setuptools_scm[toml]>=8.0.3,<9.3",
   "cython>=3.0.10",
   "numpy>=2.0.0rc1,<3"
 ]


### PR DESCRIPTION
Raise upper bound on `setuptools-scm` dependency from `9` to `9.3`.