### PR TITLE
BUG: Use vol_model instead of vol for p type check in arch_model

### DIFF
--- a/arch/tests/univariate/test_mean.py
+++ b/arch/tests/univariate/test_mean.py
@@ -1383,7 +1383,7 @@ def test_false_reindex():
 
 
 def test_invalid_arch_model():
-    with pytest.raises(AssertionError):
+    with pytest.raises(TypeError):
         arch_model(SP500, p="3")
 
 

--- a/arch/univariate/mean.py
+++ b/arch/univariate/mean.py
@@ -2035,7 +2035,7 @@ def arch_model(
     else:  # mean == "zero"
         am = ZeroMean(y, hold_back=hold_back, rescale=rescale)
 
-    if vol in ("arch", "garch", "figarch", "egarch", "aparch") and not isinstance(
+    if vol_model in ("arch", "garch", "figarch", "egarch", "aparch") and not isinstance(
         p, int
     ):
         raise TypeError(


### PR DESCRIPTION
The p-is-int guard compared against the raw `vol` parameter (e.g. "GARCH") using lowercase strings, so it never matched and silently allowed non-int p values through.