### PR TITLE
BUG: Ensure std_resid returns named pandas Series for numpy array inputs

### DIFF
--- a/arch/tests/univariate/test_base.py
+++ b/arch/tests/univariate/test_base.py
@@ -3,6 +3,7 @@ from arch import arch_model
 import pandas as pd
 import numpy as np
 
+
 def test_format_float_fixed():
     out = format_float_fixed(0.0)
     assert out == "0.0000"
@@ -11,11 +12,12 @@ def test_format_float_fixed():
     out = format_float_fixed(123456789.0)
     assert out == "1.2346e+08"
 
+
 def test_std_resid_numpy_input_returns_series():
     np.random.seed(42)
     data = np.random.randn(500)
-    am = arch_model(data, vol='GARCH', p=1, q=1)
-    res = am.fit(disp='off')
+    am = arch_model(data, vol="GARCH", p=1, q=1)
+    res = am.fit(disp="off")
     sr = res.std_resid
     assert isinstance(sr, pd.Series)
     assert sr.name == "std_resid"
@@ -25,8 +27,8 @@ def test_std_resid_numpy_input_returns_series():
 def test_std_resid_pandas_input_still_works():
     np.random.seed(42)
     data = pd.Series(np.random.randn(500), name="returns")
-    am = arch_model(data, vol='GARCH', p=1, q=1)
-    res = am.fit(disp='off')
+    am = arch_model(data, vol="GARCH", p=1, q=1)
+    res = am.fit(disp="off")
     sr = res.std_resid
     assert isinstance(sr, pd.Series)
     assert sr.name == "std_resid"
@@ -35,8 +37,8 @@ def test_std_resid_pandas_input_still_works():
 def test_std_resid_numpy_has_index():
     np.random.seed(42)
     data = np.random.randn(500)
-    am = arch_model(data, vol='GARCH', p=1, q=1)
-    res = am.fit(disp='off')
+    am = arch_model(data, vol="GARCH", p=1, q=1)
+    res = am.fit(disp="off")
     sr = res.std_resid
     assert sr.index is not None
     assert len(sr.index) == 500

--- a/arch/tests/univariate/test_base.py
+++ b/arch/tests/univariate/test_base.py
@@ -1,5 +1,7 @@
 from arch.univariate.base import format_float_fixed
-
+from arch import arch_model
+import pandas as pd
+import numpy as np
 
 def test_format_float_fixed():
     out = format_float_fixed(0.0)
@@ -8,3 +10,33 @@ def test_format_float_fixed():
     assert out == "1.2300e-09"
     out = format_float_fixed(123456789.0)
     assert out == "1.2346e+08"
+
+def test_std_resid_numpy_input_returns_series():
+    np.random.seed(42)
+    data = np.random.randn(500)
+    am = arch_model(data, vol='GARCH', p=1, q=1)
+    res = am.fit(disp='off')
+    sr = res.std_resid
+    assert isinstance(sr, pd.Series)
+    assert sr.name == "std_resid"
+    assert len(sr) == 500
+
+
+def test_std_resid_pandas_input_still_works():
+    np.random.seed(42)
+    data = pd.Series(np.random.randn(500), name="returns")
+    am = arch_model(data, vol='GARCH', p=1, q=1)
+    res = am.fit(disp='off')
+    sr = res.std_resid
+    assert isinstance(sr, pd.Series)
+    assert sr.name == "std_resid"
+
+
+def test_std_resid_numpy_has_index():
+    np.random.seed(42)
+    data = np.random.randn(500)
+    am = arch_model(data, vol='GARCH', p=1, q=1)
+    res = am.fit(disp='off')
+    sr = res.std_resid
+    assert sr.index is not None
+    assert len(sr.index) == 500

--- a/arch/univariate/base.py
+++ b/arch/univariate/base.py
@@ -1364,6 +1364,8 @@ class ARCHModelFixedResult(_SummaryRepr):
         std_res = self.resid / self.conditional_volatility
         if isinstance(std_res, pd.Series):
             std_res.name = "std_resid"
+        else:
+            std_res = pd.Series(std_res, name="std_resid", index=self._index)
         return std_res
 
     def plot(


### PR DESCRIPTION
## Summary
Fixes type inconsistency in `ARCHModelResult.std_resid` when model input is a numpy array.

## Problem
When `arch_model()` receives a numpy ndarray, `std_resid` returns a raw numpy array 
with no `.name` attribute instead of a named pandas Series.

Reproducer:
```python
import numpy as np
from arch import arch_model
res = arch_model(np.random.randn(500), vol='GARCH').fit(disp='off')
print(type(res.std_resid))  # <class 'numpy.ndarray'> — should be pd.Series
```

## Fix
Added `else` branch to wrap numpy output in a named `pd.Series` with the model index.

## Tests
Added 3 tests to `arch/tests/univariate/test_base.py` covering numpy input, 
pandas input (backwards compat), and index preservation.

## Motivation
Discovered while computing GARCH residual diagnostics for fat-tail analysis 
of Indian equity markets: https://doi.org/10.5281/zenodo.20573035