### PR TITLE
ENH: Add residual diagnostics

### DIFF
--- a/arch/tests/univariate/test_diagnostics.py
+++ b/arch/tests/univariate/test_diagnostics.py
@@ -1,0 +1,99 @@
+import numpy as np
+from numpy.testing import assert_allclose, assert_equal
+import pytest
+from scipy import stats
+
+from arch.univariate import excess_kurtosis, hill_estimator, var_ratio
+from arch.univariate.distribution import Normal, StudentsT
+from arch.univariate.mean import ZeroMean
+from arch.univariate.volatility import ConstantVariance
+
+
+class PositiveTailNormal(Normal):
+    def ppf(self, pits, parameters=None):
+        return 1.0
+
+
+class NonfiniteTailNormal(Normal):
+    def ppf(self, pits, parameters=None):
+        return np.nan
+
+
+def test_excess_kurtosis():
+    x = np.array([-2.0, -1.0, 0.0, 1.0, 2.0, np.nan])
+    assert_allclose(excess_kurtosis(x), stats.kurtosis(x[:-1], fisher=True))
+
+
+def test_excess_kurtosis_constant():
+    assert_equal(np.isnan(excess_kurtosis(np.ones(10))), True)
+
+
+def test_excess_kurtosis_no_finite():
+    with pytest.raises(ValueError, match="at least one finite"):
+        excess_kurtosis(np.array([np.nan, np.inf]))
+
+
+def test_hill_estimator():
+    x = np.array([1.0, 2.0, 4.0, 8.0, 16.0])
+    expected = 1.0 / np.mean(np.log(np.array([8.0, 16.0])) - np.log(4.0))
+    assert_allclose(hill_estimator(x, 2), expected)
+
+
+def test_hill_estimator_default_k():
+    x = np.arange(1.0, 10.0)
+    expected = 1.0 / np.mean(np.log(np.array([7.0, 8.0, 9.0])) - np.log(6.0))
+    assert_allclose(hill_estimator(x), expected)
+
+
+def test_hill_estimator_invalid_k():
+    x = np.arange(1.0, 10.0)
+    with pytest.raises(ValueError, match="k must satisfy"):
+        hill_estimator(x, 0)
+    with pytest.raises(ValueError, match="k must satisfy"):
+        hill_estimator(x, 9)
+    with pytest.raises(TypeError, match="k must be an integer"):
+        hill_estimator(x, 2.0)
+
+
+def test_hill_estimator_no_positive():
+    with pytest.raises(ValueError, match="at least two non-zero"):
+        hill_estimator(np.zeros(10))
+
+
+def test_hill_estimator_repeated_extremes():
+    assert_equal(hill_estimator(np.array([1.0, 2.0, 2.0, 2.0]), 2), np.inf)
+
+
+def test_var_ratio():
+    assert_allclose(var_ratio(), 1.0)
+    assert_allclose(var_ratio(distribution=Normal()), 1.0)
+
+    level = 0.99
+    nu = 8.0
+    gaussian_var = -stats.norm.ppf(1.0 - level)
+    model_var = -StudentsT().ppf(1.0 - level, [nu])
+    assert_allclose(var_ratio(level, StudentsT(), [nu]), gaussian_var / model_var)
+
+
+def test_var_ratio_invalid():
+    with pytest.raises(ValueError, match=r"larger than 0\.5"):
+        var_ratio(0.5)
+    with pytest.raises(TypeError, match="must inherit"):
+        var_ratio(distribution="normal")
+
+
+def test_var_ratio_invalid_model_var():
+    with pytest.raises(ValueError, match="positive finite"):
+        var_ratio(distribution=PositiveTailNormal())
+    with pytest.raises(ValueError, match="positive finite"):
+        var_ratio(distribution=NonfiniteTailNormal())
+
+
+def test_result_diagnostics():
+    data = np.array([-1.5, -0.8, -0.4, 0.2, 0.7, 1.0, 1.8, 2.4])
+    mod = ZeroMean(data, volatility=ConstantVariance(), distribution=StudentsT())
+    res = mod.fix(np.array([1.0, 8.0]))
+
+    assert_allclose(res.excess_kurtosis, excess_kurtosis(res.std_resid))
+    assert_allclose(res.hill_estimator(2), hill_estimator(res.std_resid, 2))
+    assert_allclose(res.var_ratio(0.99), var_ratio(0.99, StudentsT(), [8.0]))

--- a/arch/univariate/__init__.py
+++ b/arch/univariate/__init__.py
@@ -1,6 +1,7 @@
 import types
 
 from arch.univariate import recursions_python
+from arch.univariate.diagnostics import excess_kurtosis, hill_estimator, var_ratio
 from arch.univariate.distribution import (
     Distribution,
     GeneralizedError,
@@ -61,6 +62,9 @@ __all__ = [
     "StudentsT",
     "ZeroMean",
     "arch_model",
+    "excess_kurtosis",
+    "hill_estimator",
     "recursions",
     "recursions_python",
+    "var_ratio",
 ]

--- a/arch/univariate/base.py
+++ b/arch/univariate/base.py
@@ -33,6 +33,11 @@ from arch._typing import (
     Label,
     Literal,
 )
+from arch.univariate.diagnostics import (
+    excess_kurtosis as _excess_kurtosis,
+    hill_estimator as _hill_estimator,
+    var_ratio as _var_ratio,
+)
 from arch.univariate.distribution import Distribution, Normal
 from arch.univariate.volatility import ConstantVariance, VolatilityProcess
 from arch.utility.array import ensure1d, to_array_1d
@@ -1365,6 +1370,49 @@ class ARCHModelFixedResult(_SummaryRepr):
         if isinstance(std_res, pd.Series):
             std_res.name = "std_resid"
         return std_res
+
+    @cached_property
+    def excess_kurtosis(self) -> float:
+        """
+        Sample excess kurtosis of standardized residuals
+        """
+        return _excess_kurtosis(self.std_resid)
+
+    def hill_estimator(self, k: int | None = None) -> float:
+        """
+        Hill tail-index estimator of standardized residuals
+
+        Parameters
+        ----------
+        k : int, optional
+            Number of upper order statistics to use. If not provided, uses
+            ``int(sqrt(n))`` where ``n`` is the number of finite standardized
+            residuals.
+
+        Returns
+        -------
+        float
+            Inverse Hill estimate of the tail index.
+        """
+        return _hill_estimator(self.std_resid, k)
+
+    def var_ratio(self, level: float = 0.999) -> float:
+        """
+        Ratio of Gaussian VaR to model-distribution VaR
+
+        Parameters
+        ----------
+        level : float, optional
+            VaR confidence level. Must be between 0.5 and 1.0.
+
+        Returns
+        -------
+        float
+            Ratio of the Gaussian left-tail VaR to the VaR implied by the
+            fitted model distribution.
+        """
+        _, _, dp = self.model._parse_parameters(self._params)
+        return _var_ratio(level, distribution=self.model.distribution, parameters=dp)
 
     def plot(
         self, annualize: str | None = None, scale: float | None = None

--- a/arch/univariate/diagnostics.py
+++ b/arch/univariate/diagnostics.py
@@ -1,0 +1,144 @@
+"""
+Residual diagnostics for univariate ARCH models.
+"""
+
+from collections.abc import Sequence
+
+import numpy as np
+from scipy import stats
+
+from arch._typing import ArrayLike1D
+from arch.univariate.distribution import Distribution, Normal
+from arch.utility.array import ensure1d
+
+__all__ = ["excess_kurtosis", "hill_estimator", "var_ratio"]
+
+
+def _clean_std_resid(std_resid: Sequence[float] | ArrayLike1D) -> np.ndarray:
+    resids = np.asarray(ensure1d(std_resid, "std_resid", series=False), dtype=float)
+    resids = resids[np.isfinite(resids)]
+    if resids.shape[0] == 0:
+        raise ValueError("std_resid must contain at least one finite observation")
+    return resids
+
+
+def excess_kurtosis(std_resid: Sequence[float] | ArrayLike1D) -> float:
+    """
+    Sample excess kurtosis of standardized residuals.
+
+    Parameters
+    ----------
+    std_resid : array_like
+        Standardized residuals. Non-finite observations are removed before
+        computing the statistic.
+
+    Returns
+    -------
+    float
+        Sample excess kurtosis computed using sample central moments.
+    """
+    resids = _clean_std_resid(std_resid)
+    demeaned = resids - resids.mean()
+    variance = np.mean(demeaned**2.0)
+    if variance == 0.0:
+        return np.nan
+    return float(np.mean(demeaned**4.0) / variance**2.0 - 3.0)
+
+
+def hill_estimator(
+    std_resid: Sequence[float] | ArrayLike1D, k: int | None = None
+) -> float:
+    r"""
+    Hill tail-index estimator of standardized residuals.
+
+    Parameters
+    ----------
+    std_resid : array_like
+        Standardized residuals. The estimator is computed from the largest
+        absolute standardized residuals after removing non-finite observations.
+    k : int, optional
+        Number of upper order statistics to use. If not provided, uses
+        ``int(sqrt(n))`` where ``n`` is the number of finite residuals.
+
+    Returns
+    -------
+    float
+        Inverse Hill estimate of the tail index.
+
+    Notes
+    -----
+    The estimator is
+
+    .. math::
+
+        \hat{\nu} = \left(k^{-1}\sum_{i=1}^k
+        \log X_{n-i+1:n} - \log X_{n-k:n}\right)^{-1}
+
+    where ``X`` contains the positive absolute standardized residuals.
+    """
+    abs_resids = np.abs(_clean_std_resid(std_resid))
+    nobs = abs_resids.shape[0]
+    resids = np.sort(abs_resids[abs_resids > 0.0])
+    positive = resids.shape[0]
+    if positive < 2:
+        raise ValueError(
+            "std_resid must contain at least two non-zero finite observations"
+        )
+
+    if k is None:
+        k = int(np.sqrt(nobs))
+    elif not isinstance(k, (int, np.integer)):
+        raise TypeError("k must be an integer")
+
+    if not 1 <= int(k) < positive:
+        raise ValueError(
+            "k must satisfy 1 <= k < the number of non-zero finite observations"
+        )
+    k = int(k)
+
+    threshold = resids[-k - 1]
+    hill = np.mean(np.log(resids[-k:]) - np.log(threshold))
+    if hill == 0.0:
+        return np.inf
+    return float(1.0 / hill)
+
+
+def var_ratio(
+    level: float = 0.999,
+    distribution: Distribution | None = None,
+    parameters: Sequence[float] | ArrayLike1D | None = None,
+) -> float:
+    """
+    Ratio of Gaussian VaR to model-distribution VaR.
+
+    Parameters
+    ----------
+    level : float, optional
+        VaR confidence level. Must be between 0.5 and 1.0.
+    distribution : Distribution, optional
+        Standardized distribution used to compute the model VaR. If not
+        provided, uses the standard normal distribution.
+    parameters : array_like, optional
+        Distribution parameters. Use ``None`` for parameterless distributions.
+
+    Returns
+    -------
+    float
+        Ratio of the Gaussian left-tail VaR to the VaR implied by the supplied
+        model distribution.
+    """
+    level = float(level)
+    if not 0.5 < level < 1.0:
+        raise ValueError("level must be larger than 0.5 and smaller than 1.0")
+
+    if distribution is None:
+        distribution = Normal()
+    elif not isinstance(distribution, Distribution):
+        raise TypeError("distribution must inherit from Distribution")
+
+    tail_probability = 1.0 - level
+    gaussian_var = -stats.norm.ppf(tail_probability)
+    model_var = -float(distribution.ppf(tail_probability, parameters))
+    if not np.isfinite(model_var) or model_var <= 0.0:
+        raise ValueError("model distribution must produce a positive finite VaR")
+    return float(gaussian_var / model_var)

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -49,6 +49,15 @@ Shock Distributions
    ~arch.univariate.SkewStudent
    ~arch.univariate.GeneralizedError
 
+Residual Diagnostics
+~~~~~~~~~~~~~~~~~~~~
+
+.. autosummary::
+
+   ~arch.univariate.excess_kurtosis
+   ~arch.univariate.hill_estimator
+   ~arch.univariate.var_ratio
+
 Unit Root Testing
 -----------------
 .. autosummary::

--- a/doc/source/univariate/utility.rst
+++ b/doc/source/univariate/utility.rst
@@ -11,3 +11,17 @@ Test Results
 
 .. autoclass:: WaldTestStatistic
    :members:
+
+Residual Diagnostics
+--------------------
+
+.. module:: arch.univariate
+   :noindex:
+.. currentmodule:: arch.univariate
+
+.. autosummary::
+   :toctree: generated/
+
+   excess_kurtosis
+   hill_estimator
+   var_ratio


### PR DESCRIPTION
## Summary

  Adds residual fat-tail diagnostics for univariate ARCH model results.

  - Adds standalone `excess_kurtosis`, `hill_estimator`, and `var_ratio` functions
  - Adds lightweight result wrappers using `std_resid`
  - Exports the diagnostics from `arch.univariate`
  - Adds docs and focused tests

  ## Validation

  - `pytest arch/tests/univariate/test_diagnostics.py arch/tests/univariate/test_base.py arch/tests/univariate/test_distribution.py arch/tests/
  univariate/test_mean.py::TestMeanModel::test_ar arch/tests/univariate/test_mean.py::test_arch_lm arch/tests/univariate/
  test_mean.py::test_arch_lm_ar_model`
  - `git diff --cached --check`